### PR TITLE
Improve OpenAI error handling

### DIFF
--- a/EnFlow/Models/SuggestedPrioritiesVM.swift
+++ b/EnFlow/Models/SuggestedPrioritiesVM.swift
@@ -48,7 +48,7 @@ final class SuggestedPrioritiesVM: ObservableObject {
             priorities = sortAndFilter(merged)
             save()
         } catch {
-            errorText = "Couldn’t fetch priorities."
+            errorText = error.localizedDescription
         }
         isLoading = false
     }

--- a/EnFlow/Views/Components/SuggestedPrioritiesView.swift
+++ b/EnFlow/Views/Components/SuggestedPrioritiesView.swift
@@ -37,13 +37,8 @@ struct SuggestedPrioritiesView: View {
                 ProgressView()
                     .progressViewStyle(.circular)
                     .frame(maxWidth: .infinity, alignment: .center)
-                
-            } else if let err = vm.errorText {
-                Text(err)
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-                
-            } else {
+
+            } else if !vm.priorities.isEmpty {
                 ForEach(vm.priorities) { p in
                     ZStack(alignment: .topTrailing) {
                         suggestionCard(for: p)
@@ -68,6 +63,10 @@ struct SuggestedPrioritiesView: View {
                         }
                     }
                 }
+            } else {
+                Text(vm.errorText ?? "AI suggestions unavailable.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
             }
         }
         .task(id: contextHash)   { await vm.refresh() }


### PR DESCRIPTION
## Summary
- surface API error messages from OpenAI chat completion
- expose detailed messages in SuggestedPrioritiesVM
- show a fallback message if no priorities are available

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685af8e2ef10832f850e01e1e1d4543f