### PR TITLE
Add step count display

### DIFF
--- a/EnFlow/Health/HealthDataPipeline.swift
+++ b/EnFlow/Health/HealthDataPipeline.swift
@@ -149,4 +149,17 @@ final class HealthDataPipeline: ObservableObject {
             store.execute(q)
         }
     }
+
+    // MARK: Quick fetches
+    /// Returns today\'s step count as an integer value.
+    @MainActor
+    func stepsToday() async -> Int {
+        let start = calendar.startOfDay(for: Date())
+        let end   = calendar.date(byAdding: .day, value: 1, to: start)!
+        let count = await sumQuantity(.stepCount,
+                                      unit: .count(),
+                                      start: start,
+                                      end: end)
+        return Int(count)
+    }
 }

--- a/EnFlow/Views/DashboardView.swift
+++ b/EnFlow/Views/DashboardView.swift
@@ -33,6 +33,7 @@ struct DashboardView: View {
     @State private var tomorrowCtx: SuggestedPriorityContext?
 
     @State private var isLoading = true
+    @State private var stepsToday = 0
     @State private var selection  = 0         // 0 = today • 1 = tomorrow
     
     private typealias ThreePartEnergy = EnergyForecastModel.ThreePartEnergy
@@ -83,14 +84,21 @@ struct DashboardView: View {
                        subtitle: "Your energy status for today:")
 
                 // — Composite ring —
-                    if let summary = todaySummary {
+                if let summary = todaySummary {
+                    VStack(spacing: 4) {
                         EnergyRingView(
                           score: summary.overallEnergyScore,
                           explainers: summary.explainers,
                           summaryDate: summary.date
                         )
-                        .frame(maxWidth: .infinity)
+                        if stepsToday > 0 {
+                            Text("Steps today: \(stepsToday)")
+                                .font(.caption2)
+                                .foregroundColor(.gray)
+                        }
                     }
+                    .frame(maxWidth: .infinity)
+                }
 
                 // — 24-hour line graph —
                 if let wave = todaySummary?.hourlyWaveform {
@@ -179,6 +187,7 @@ struct DashboardView: View {
 
         // Health + calendar pulls
         let healthList     = await HealthDataPipeline.shared.fetchDailyHealthEvents(daysBack: 2)
+        let steps          = await HealthDataPipeline.shared.stepsToday()
         let eventsToday    = await CalendarDataPipeline.shared.fetchEvents(for: today)
         let eventsTomorrow = await CalendarDataPipeline.shared.fetchEvents(for: tomorrow)
 
@@ -245,6 +254,7 @@ struct DashboardView: View {
             tomorrowParts   = tmParts
             todayCtx        = tCtx
             tomorrowCtx     = tmCtx
+            stepsToday      = steps
             isLoading       = false
             engine.markRefreshed()                     // trigger ring-pulse animation
         }


### PR DESCRIPTION
## Summary
- extend `HealthDataPipeline` with a helper to fetch today's steps
- store today's steps in `DashboardView`
- show the value below the energy ring

## Testing
- `swift test -c release` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685af8c9fbd8832fac73e30ff1b026b7