### PR TITLE
Unify energy forecasts with calculated data

### DIFF
--- a/EnFlow/Models/EnergyForecastModel.swift
+++ b/EnFlow/Models/EnergyForecastModel.swift
@@ -42,8 +42,14 @@ final class EnergyForecastModel: ObservableObject {
                   health: [HealthEvent],
                   events: [CalendarEvent]) -> ForecastResult? {
 
+        if let cached = ForecastCache.shared.wave(for: date) {
+            let sc = cached.reduce(0, +) / Double(cached.count) * 100.0
+            return ForecastResult(values: cached, score: sc)
+        }
+
         let hSample = health.first { calendar.isDate($0.date, inSameDayAs: date) }
         guard let baseWave = hourlyWaveform(baseHealth: hSample) else { return nil }
+        ForecastCache.shared.saveWave(baseWave, for: date)
         let score = baseWave.reduce(0, +) / Double(baseWave.count) * 100.0
         return ForecastResult(values: baseWave, score: score)
     }

--- a/EnFlow/Models/UnifiedEnergyModel.swift
+++ b/EnFlow/Models/UnifiedEnergyModel.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Provides combined calculated + forecasted summaries.
+@MainActor
+final class UnifiedEnergyModel {
+    static let shared = UnifiedEnergyModel()
+    private init() {}
+
+    private let calendar = Calendar.current
+    private let summaryEngine = EnergySummaryEngine.shared
+    private let forecastModel = EnergyForecastModel()
+    private let cache = ForecastCache.shared
+
+    /// Returns a DayEnergySummary blending calculated past energy with
+    /// forecasted future energy when appropriate.
+    func summary(for date: Date,
+                 healthEvents: [HealthEvent],
+                 calendarEvents: [CalendarEvent]) -> DayEnergySummary {
+
+        let summary = summaryEngine.summarize(day: date,
+                                              healthEvents: healthEvents,
+                                              calendarEvents: calendarEvents)
+
+        guard let forecast = forecastModel.forecast(for: date,
+                                                    health: healthEvents,
+                                                    events: calendarEvents) else {
+            return summary
+        }
+        cache.saveWave(forecast.values, for: date)
+
+        var blended = summary.hourlyWaveform
+        let now = Date()
+
+        if calendar.isDateInToday(date) {
+            let hr = calendar.component(.hour, from: now)
+            for i in hr..<24 { blended[i] = forecast.values[i] }
+        } else if date > calendar.startOfDay(for: now) {
+            blended = forecast.values
+        }
+
+        // compute accuracy for past days if we have forecast stored
+        if date < calendar.startOfDay(for: now), let prev = cache.wave(for: date) {
+            let diffs = zip(prev, summary.hourlyWaveform).map { abs($0 - $1) }
+            let acc = 1.0 - diffs.reduce(0, +) / Double(diffs.count)
+            cache.saveAccuracy(acc, for: date)
+        }
+
+        let avgScore = blended.reduce(0, +) / Double(blended.count) * 100
+
+        return DayEnergySummary(
+            date: summary.date,
+            overallEnergyScore: avgScore.rounded(),
+            mentalEnergy: summary.mentalEnergy,
+            physicalEnergy: summary.physicalEnergy,
+            sleepEfficiency: summary.sleepEfficiency,
+            hourlyWaveform: blended,
+            topBoosters: summary.topBoosters,
+            topDrainers: summary.topDrainers,
+            explainers: summary.explainers
+        )
+    }
+}

--- a/EnFlow/Utilities/ForecastCache.swift
+++ b/EnFlow/Utilities/ForecastCache.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Caches forecasted hourly values and prediction accuracy by day.
+final class ForecastCache {
+    static let shared = ForecastCache()
+    private init() {
+        load()
+    }
+
+    private let waveKey = "ForecastCache.Waves"
+    private let accKey  = "ForecastCache.Accuracy"
+
+    private var waves: [String:[Double]] = [:]
+    private var accuracy: [String:Double] = [:]
+
+    private func load() {
+        let d = UserDefaults.standard
+        if let wData = d.data(forKey: waveKey),
+           let obj = try? JSONDecoder().decode([String:[Double]].self, from: wData) {
+            waves = obj
+        }
+        if let aData = d.data(forKey: accKey),
+           let obj = try? JSONDecoder().decode([String:Double].self, from: aData) {
+            accuracy = obj
+        }
+    }
+
+    private func persist() {
+        let d = UserDefaults.standard
+        if let data = try? JSONEncoder().encode(waves) {
+            d.set(data, forKey: waveKey)
+        }
+        if let data = try? JSONEncoder().encode(accuracy) {
+            d.set(data, forKey: accKey)
+        }
+    }
+
+    private func key(for date: Date) -> String {
+        ISO8601DateFormatter().string(from: Calendar.current.startOfDay(for: date))
+    }
+
+    func wave(for date: Date) -> [Double]? {
+        waves[key(for: date)]
+    }
+
+    func saveWave(_ wave: [Double], for date: Date) {
+        waves[key(for: date)] = wave
+        persist()
+    }
+
+    func saveAccuracy(_ value: Double, for date: Date) {
+        accuracy[key(for: date)] = value
+        persist()
+    }
+
+    func accuracy(for date: Date) -> Double? {
+        accuracy[key(for: date)]
+    }
+
+    /// Average accuracy over the last N days if available.
+    func recentAccuracy(days: Int) -> Double? {
+        let cal = Calendar.current
+        let today = cal.startOfDay(for: Date())
+        let dates = (0..<days).compactMap { cal.date(byAdding: .day, value: -$0, to: today) }
+        let vals = dates.compactMap { accuracy[key(for: $0)] }
+        guard !vals.isEmpty else { return nil }
+        return vals.reduce(0, +) / Double(vals.count)
+    }
+}

--- a/EnFlow/Views/Components/MonthCalendarView.swift
+++ b/EnFlow/Views/Components/MonthCalendarView.swift
@@ -202,7 +202,6 @@ struct MonthCalendarView: View {
     }
 
     private func loadEnergy() async {
-        let engine = EnergySummaryEngine.shared
         var results: [Date: Double] = [:]
 
         let allHealth = await HealthDataPipeline.shared.fetchDailyHealthEvents(daysBack: 60)
@@ -219,7 +218,9 @@ struct MonthCalendarView: View {
         for date in monthDates where calendar.isDate(date, equalTo: displayMonth, toGranularity: .month) {
             let dayHealth = allHealth.filter { calendar.isDate($0.date, inSameDayAs: date) }
             let dayEvents = allEvents.filter { calendar.isDate($0.startTime, inSameDayAs: date) }
-            let summary   = engine.summarize(day: date, healthEvents: dayHealth, calendarEvents: dayEvents)
+            let summary = UnifiedEnergyModel.shared.summary(for: date,
+                                                           healthEvents: dayHealth,
+                                                           calendarEvents: dayEvents)
             results[date] = summary.overallEnergyScore
         }
 

--- a/EnFlow/Views/Components/WeekCalendarView.swift
+++ b/EnFlow/Views/Components/WeekCalendarView.swift
@@ -223,7 +223,6 @@ struct WeekCalendarView: View {
     }
 
     private func loadWeekData() async {
-        let model = EnergyForecastModel()
         var matrix = Array(
             repeating: Array(repeating: 50.0, count: hours.count),
             count: 7
@@ -253,12 +252,9 @@ struct WeekCalendarView: View {
                 let dayEvents = allEvents.filter {
                     calendar.isDate($0.startTime, inSameDayAs: day)
                 }
-                let summary = EnergySummaryEngine.shared
-                    .summarize(
-                        day: day,
-                        healthEvents: dayHealth,
-                        calendarEvents: dayEvents
-                    )
+                let summary = UnifiedEnergyModel.shared.summary(for: day,
+                                                                healthEvents: dayHealth,
+                                                                calendarEvents: dayEvents)
                 // hourlyWaveform[4…23] → 20 values
                 matrix[d] = Array(summary.hourlyWaveform[4...23])
                 events = allEvents

--- a/EnFlow/Views/DashboardView.swift
+++ b/EnFlow/Views/DashboardView.swift
@@ -203,14 +203,13 @@ struct DashboardView: View {
         let eventsToday    = await CalendarDataPipeline.shared.fetchEvents(for: today)
         let eventsTomorrow = await CalendarDataPipeline.shared.fetchEvents(for: tomorrow)
 
-        // Daily summaries (singleton engine)
-        let eng       = EnergySummaryEngine.shared
-        let tSummary  = eng.summarize(day: today,
-                                      healthEvents: healthList,
-                                      calendarEvents: eventsToday)
-        let tmSummary = eng.summarize(day: tomorrow,
-                                      healthEvents: healthList,
-                                      calendarEvents: eventsTomorrow)
+        // Daily summaries blended with forecast
+        let tSummary  = UnifiedEnergyModel.shared.summary(for: today,
+                                                          healthEvents: healthList,
+                                                          calendarEvents: eventsToday)
+        let tmSummary = UnifiedEnergyModel.shared.summary(for: tomorrow,
+                                                          healthEvents: healthList,
+                                                          calendarEvents: eventsTomorrow)
 
         let todayHealth    = healthList.first { cal.isDate($0.date, inSameDayAs: today) }
         let tomorrowHealth = healthList.first { cal.isDate($0.date, inSameDayAs: tomorrow) }

--- a/EnFlow/Views/TrendsView.swift
+++ b/EnFlow/Views/TrendsView.swift
@@ -13,6 +13,7 @@ struct TrendsView: View {
     @State private var period: TrendsPeriod = .weekly
 
     @State private var summaries: [DayEnergySummary] = []
+    @State private var forecastSummaries: [DayEnergySummary] = []
     @State private var accuracy: Double = 0.0
     @State private var insightTags: [String] = []
     @State private var insightText: String = ""
@@ -43,17 +44,21 @@ struct TrendsView: View {
                         LineMark(x: .value("Day", item.date), y: .value("Actual", item.overallEnergyScore))
                             .interpolationMethod(.catmullRom)
                             .foregroundStyle(Color.yellow)
+                    }
+                    ForEach(forecastSummaries) { item in
                         LineMark(x: .value("Day", item.date), y: .value("Forecast", item.overallEnergyScore))
                             .interpolationMethod(.catmullRom)
                             .foregroundStyle(Color.blue)
                     }
-                    if let last = summaries.last {
-                        PointMark(x: .value("Day", last.date), y: .value("Actual", last.overallEnergyScore))
+                    if let lastA = summaries.last {
+                        PointMark(x: .value("Day", lastA.date), y: .value("Actual", lastA.overallEnergyScore))
                             .symbol(.circle)
                             .symbolSize(80)
                             .foregroundStyle(Color.yellow)
                             .shadow(radius: 8)
-                        PointMark(x: .value("Day", last.date), y: .value("Forecast", last.overallEnergyScore))
+                    }
+                    if let lastF = forecastSummaries.last {
+                        PointMark(x: .value("Day", lastF.date), y: .value("Forecast", lastF.overallEnergyScore))
                             .symbol(.circle)
                             .symbolSize(80)
                             .foregroundStyle(Color.blue)
@@ -63,6 +68,13 @@ struct TrendsView: View {
                 .chartYScale(domain: 0...100)
                 .frame(height: 200)
                 .padding(.horizontal)
+
+                if forecastSummaries.isEmpty {
+                    Text("Not enough prediction data to make accurate assessment")
+                        .font(.caption)
+                        .foregroundColor(.orange)
+                        .padding(.horizontal)
+                }
 
                 // Main energy toggle icon
                 HStack { Spacer()
@@ -91,6 +103,12 @@ struct TrendsView: View {
                             .foregroundColor(.yellow)
                     }
                     .padding(.horizontal)
+                }
+                if accuracy == 0 {
+                    Text("Not enough prediction data to make accurate assessment")
+                        .font(.caption)
+                        .foregroundColor(.orange)
+                        .padding(.horizontal)
                 }
 
                 // Energy insights
@@ -202,41 +220,60 @@ Analyze correlations between the user's calendar events and their energy data. W
             }
         }()
 
-        // 1. Fetch raw Health and Calendar data
+        let cal = Calendar.current
+        let start = cal.date(byAdding: .day, value: -(days - 1), to: cal.startOfDay(for: Date())) ?? Date()
         let healthList = await HealthDataPipeline.shared.fetchDailyHealthEvents(daysBack: days)
-        let allEvents  = await CalendarDataPipeline.shared.fetchUpcomingDays(days: days)
+        let allEvents = await CalendarDataPipeline.shared.fetchEvents(start: start, end: cal.date(byAdding: .day, value: days, to: start)!)
 
-        // 2. Summarize each day
-        var newSummaries: [DayEnergySummary] = []
-        for h in healthList {
-            // Filter calendar events for this exact day
-            let dayStart = Calendar.current.startOfDay(for: h.date)
-            let dayEvents = allEvents.filter {
-                Calendar.current.isDate($0.startTime, inSameDayAs: dayStart)
+        var actual: [DayEnergySummary] = []
+        var forecast: [DayEnergySummary] = []
+        var accTotal = 0.0
+        var accCount = 0
+
+        for i in 0..<days {
+            guard let day = cal.date(byAdding: .day, value: i, to: start) else { continue }
+            let h = healthList.filter { cal.isDate($0.date, inSameDayAs: day) }
+            let ev = allEvents.filter { cal.isDate($0.startTime, inSameDayAs: day) }
+
+            let summary = UnifiedEnergyModel.shared.summary(for: day, healthEvents: h, calendarEvents: ev)
+            actual.append(summary)
+
+            var fWave = ForecastCache.shared.wave(for: day)
+            if fWave == nil {
+                if let res = EnergyForecastModel().forecast(for: day, health: h, events: ev)?.values {
+                    fWave = res
+                    ForecastCache.shared.saveWave(res, for: day)
+                }
             }
-
-            let summary = EnergySummaryEngine.shared.summarize(
-                day: dayStart,
-                healthEvents: [h],
-                calendarEvents: dayEvents
-            )
-            newSummaries.append(summary)
+            if let wave = fWave {
+                let score = wave.reduce(0, +) / Double(wave.count) * 100
+                forecast.append(DayEnergySummary(date: day,
+                                                overallEnergyScore: score.rounded(),
+                                                mentalEnergy: summary.mentalEnergy,
+                                                physicalEnergy: summary.physicalEnergy,
+                                                sleepEfficiency: summary.sleepEfficiency,
+                                                hourlyWaveform: wave,
+                                                topBoosters: [],
+                                                topDrainers: []))
+                if day < cal.startOfDay(for: Date()) {
+                    let diffs = zip(wave, summary.hourlyWaveform).map { abs($0 - $1) }
+                    let acc = 1.0 - diffs.reduce(0, +) / Double(diffs.count)
+                    ForecastCache.shared.saveAccuracy(acc, for: day)
+                    accTotal += acc
+                    accCount += 1
+                }
+            }
         }
 
-        // 3. Sort by date
-        newSummaries.sort { $0.date < $1.date }
+        let accuracyVal = accCount > 0 ? accTotal / Double(accCount) : 0.0
 
-        // 4. Assign to state
         await MainActor.run {
-            self.summaries = newSummaries
-            // TODO: wire up your forecast model to compute a true accuracy metric here
-            self.accuracy  = 0.0
+            summaries = actual
+            forecastSummaries = forecast
+            accuracy = accuracyVal
         }
 
-        // 5. Pulse any ring/forecast animations
-        await MainActor.run {
-            EnergySummaryEngine.shared.markRefreshed()
-        }
+        await MainActor.run { EnergySummaryEngine.shared.markRefreshed() }
     }
 
 


### PR DESCRIPTION
## Summary
- add a local `ForecastCache` for storing hourly predictions and accuracy
- introduce `UnifiedEnergyModel` for merging calculated and forecasted energy
- blend forecast values in Dashboard, Day view and calendar views
- display actual vs forecast lines plus accuracy in Trends view
- cache-aware forecasting in `EnergyForecastModel`

## Testing
- `swift --version`
- `xcodebuild -list -project EnFlow.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b0efd31ec832f9680ae5cbc7d69b4