### PR TITLE
Add forecast metadata and confidence

### DIFF
--- a/EnFlow/Models/DayEnergyForecast.swift
+++ b/EnFlow/Models/DayEnergyForecast.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Forecasted energy values and metadata for a given day.
+struct DayEnergyForecast: Codable {
+    enum SourceType: String, Codable {
+        case historicalModel
+        case defaultHeuristic
+    }
+
+    let date: Date
+    let values: [Double]          // 24 values, 0.0…1.0
+    let score: Double             // 0…100 daily average
+    let confidenceScore: Double   // 0…1
+    let missingMetrics: [MetricType]
+    let sourceType: SourceType
+}

--- a/EnFlow/Models/EnergyForecastModel.swift
+++ b/EnFlow/Models/EnergyForecastModel.swift
@@ -20,7 +20,9 @@ final class EnergyForecastModel: ObservableObject {
     private let calendar = Calendar.current
     private let summaryEngine = EnergySummaryEngine.shared
 
+    // Deprecated; use DayEnergyForecast instead
     struct ForecastResult { let values: [Double]; let score: Double }
+    struct ThreePartEnergy { let morning: Double; let afternoon: Double; let evening: Double }
     struct ThreePartEnergy { let morning: Double; let afternoon: Double; let evening: Double }
 
     // MARK: Daily rebuild
@@ -40,18 +42,35 @@ final class EnergyForecastModel: ObservableObject {
     // MARK: Single-day forecast (24×values + daily composite)
     func forecast(for date: Date,
                   health: [HealthEvent],
-                  events: [CalendarEvent]) -> ForecastResult? {
+                  events: [CalendarEvent]) -> DayEnergyForecast? {
 
-        if let cached = ForecastCache.shared.wave(for: date) {
-            let sc = cached.reduce(0, +) / Double(cached.count) * 100.0
-            return ForecastResult(values: cached, score: sc)
+        if let cached = ForecastCache.shared.forecast(for: date) {
+            return cached
         }
 
-        let hSample = health.first { calendar.isDate($0.date, inSameDayAs: date) }
-        guard let baseWave = hourlyWaveform(baseHealth: hSample) else { return nil }
-        ForecastCache.shared.saveWave(baseWave, for: date)
-        let score = baseWave.reduce(0, +) / Double(baseWave.count) * 100.0
-        return ForecastResult(values: baseWave, score: score)
+        let history = health.filter { $0.date <= date }
+        guard let hSample = history.first(where: { calendar.isDate($0.date, inSameDayAs: date) }) else {
+            return nil
+        }
+
+        guard let base = computeHistoricalBase(from: history) else { return nil }
+        let wave = Array(repeating: base, count: 24)
+        let score = wave.reduce(0, +) / Double(wave.count) * 100.0
+
+        let required: Set<MetricType> = [.stepCount, .restingHR, .activeEnergyBurned]
+        let missing = required.subtracting(hSample.availableMetrics)
+        var confidence = 0.2
+        if history.count >= 7 { confidence = 0.8 }
+        else if history.count >= 3 { confidence = 0.4 }
+
+        let forecast = DayEnergyForecast(date: date,
+                                         values: wave,
+                                         score: score,
+                                         confidenceScore: confidence,
+                                         missingMetrics: Array(missing),
+                                         sourceType: .historicalModel)
+        ForecastCache.shared.saveForecast(forecast)
+        return forecast
     }
 
     // MARK: 3-part (morning / afternoon / evening)
@@ -95,6 +114,16 @@ final class EnergyForecastModel: ObservableObject {
         e += circadianBoost[hr]
 
         return max(0.0, min(1.0, e))
+    }
+
+    /// Moving-average base energy across recent history (7–14 days).
+    private func computeHistoricalBase(from history: [HealthEvent]) -> Double? {
+        let recent = history.suffix(14)
+        let valid = recent.compactMap { computeBaseEnergy(from: $0) }
+        guard !valid.isEmpty else { return nil }
+        let range = valid.suffix(7)
+        let avg = range.reduce(0, +) / Double(range.count)
+        return avg
     }
 
     // MARK: Helpers -------------------------------------------------------------

--- a/EnFlow/Models/UnifiedEnergyModel.swift
+++ b/EnFlow/Models/UnifiedEnergyModel.swift
@@ -27,7 +27,7 @@ final class UnifiedEnergyModel {
                                                     events: calendarEvents) else {
             return summary
         }
-        cache.saveWave(forecast.values, for: date)
+        cache.saveForecast(forecast)
 
         var blended = summary.hourlyWaveform
         let now = Date()
@@ -40,7 +40,7 @@ final class UnifiedEnergyModel {
         }
 
         // compute accuracy for past days if we have forecast stored
-        if date < calendar.startOfDay(for: now), let prev = cache.wave(for: date) {
+        if date < calendar.startOfDay(for: now), let prev = cache.forecast(for: date)?.values {
             let diffs = zip(prev, summary.hourlyWaveform).map { abs($0 - $1) }
             let acc = 1.0 - diffs.reduce(0, +) / Double(diffs.count)
             cache.saveAccuracy(acc, for: date)

--- a/EnFlow/Utilities/ForecastCache.swift
+++ b/EnFlow/Utilities/ForecastCache.swift
@@ -9,9 +9,11 @@ final class ForecastCache {
 
     private let waveKey = "ForecastCache.Waves"
     private let accKey  = "ForecastCache.Accuracy"
+    private let forecastKey = "ForecastCache.Forecasts"
 
     private var waves: [String:[Double]] = [:]
     private var accuracy: [String:Double] = [:]
+    private var forecasts: [String:DayEnergyForecast] = [:]
 
     private func load() {
         let d = UserDefaults.standard
@@ -23,6 +25,10 @@ final class ForecastCache {
            let obj = try? JSONDecoder().decode([String:Double].self, from: aData) {
             accuracy = obj
         }
+        if let fData = d.data(forKey: forecastKey),
+           let obj = try? JSONDecoder().decode([String:DayEnergyForecast].self, from: fData) {
+            forecasts = obj
+        }
     }
 
     private func persist() {
@@ -32,6 +38,9 @@ final class ForecastCache {
         }
         if let data = try? JSONEncoder().encode(accuracy) {
             d.set(data, forKey: accKey)
+        }
+        if let data = try? JSONEncoder().encode(forecasts) {
+            d.set(data, forKey: forecastKey)
         }
     }
 
@@ -55,6 +64,15 @@ final class ForecastCache {
 
     func accuracy(for date: Date) -> Double? {
         accuracy[key(for: date)]
+    }
+
+    func forecast(for date: Date) -> DayEnergyForecast? {
+        forecasts[key(for: date)]
+    }
+
+    func saveForecast(_ forecast: DayEnergyForecast) {
+        forecasts[key(for: forecast.date)] = forecast
+        persist()
     }
 
     /// Average accuracy over the last N days if available.

--- a/EnFlow/Views/DashboardView.swift
+++ b/EnFlow/Views/DashboardView.swift
@@ -37,6 +37,8 @@ struct DashboardView: View {
     @State private var selection  = 0         // 0 = today • 1 = tomorrow
     @State private var missingTodayData = false
     @State private var missingTomorrowData = false
+    @State private var tomorrowConfidence: Double = 0
+
     
     private typealias ThreePartEnergy = EnergyForecastModel.ThreePartEnergy
 
@@ -165,6 +167,12 @@ struct DashboardView: View {
                     }
                 }
 
+                if tomorrowConfidence > 0 && tomorrowConfidence < 0.4 {
+                    Text("⚠️ Forecast based on limited history – add more days of data for accuracy")
+                        .font(.caption)
+                        .foregroundColor(.orange)
+                }
+
                 ThreePartForecastView(parts: tomorrowParts,
                                       dashed: true,
                                       desaturate: true)
@@ -212,6 +220,9 @@ struct DashboardView: View {
         let tmSummary = UnifiedEnergyModel.shared.summary(for: tomorrow,
                                                           healthEvents: healthList,
                                                           calendarEvents: eventsTomorrow)
+        let forecastConf = EnergyForecastModel().forecast(for: tomorrow,
+                                                         health: healthList,
+                                                         events: eventsTomorrow)?.confidenceScore ?? 0
 
         let todayHealth    = healthList.first { cal.isDate($0.date, inSameDayAs: today) }
         let tomorrowHealth = healthList.first { cal.isDate($0.date, inSameDayAs: tomorrow) }
@@ -276,6 +287,7 @@ struct DashboardView: View {
             isLoading       = false
             missingTodayData = noToday
             missingTomorrowData = noTomorrow
+            tomorrowConfidence = forecastConf
             engine.markRefreshed()                     // trigger ring-pulse animation
         }
     }

--- a/EnFlow/Views/TrendsView.swift
+++ b/EnFlow/Views/TrendsView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import Charts
+import Foundation
 
 enum TrendsPeriod: String, CaseIterable, Identifiable {
     case weekly = "Weekly"
@@ -238,11 +239,16 @@ Analyze correlations between the user's calendar events and their energy data. W
             let summary = UnifiedEnergyModel.shared.summary(for: day, healthEvents: h, calendarEvents: ev)
             actual.append(summary)
 
-            var fWave = ForecastCache.shared.wave(for: day)
+            var fWave = ForecastCache.shared.forecast(for: day)?.values
             if fWave == nil {
                 if let res = EnergyForecastModel().forecast(for: day, health: h, events: ev)?.values {
                     fWave = res
-                    ForecastCache.shared.saveWave(res, for: day)
+                    ForecastCache.shared.saveForecast(DayEnergyForecast(date: day,
+                                                                     values: res,
+                                                                     score: res.reduce(0, +) / Double(res.count) * 100,
+                                                                     confidenceScore: 0.2,
+                                                                     missingMetrics: [],
+                                                                     sourceType: .historicalModel))
                 }
             }
             if let wave = fWave {


### PR DESCRIPTION
## Summary
- store forecast confidence and missing metric info via new `DayEnergyForecast` model
- persist forecasts in `ForecastCache`
- compute moving-average forecasts and confidence in `EnergyForecastModel`
- surface forecast confidence in Dashboard tomorrow view
- adjust trends logic to use new forecast cache

## Testing
- `swift --version`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685b9b3878e4832fbdd42ea2303dea53