### PR TITLE
Fix Settings health toggle persistence

### DIFF
--- a/EnFlow/Views/OnboardingAndSettingsView.swift
+++ b/EnFlow/Views/OnboardingAndSettingsView.swift
@@ -136,10 +136,7 @@ struct OnboardingAndSettingsView: View {
         calendarGranted =
             EKEventStore.authorizationStatus(for: .event) == .authorized
 
-        if let t = HKObjectType.quantityType(forIdentifier: .stepCount) {
-            healthGranted =
-                HKHealthStore().authorizationStatus(for: t) == .sharingAuthorized
-        }
+        updateHealthGranted()
     }
 
     // Toggle callbacks
@@ -151,7 +148,10 @@ struct OnboardingAndSettingsView: View {
 
     private func healthToggleChanged(_ newValue: Bool) {
         if newValue {
-            HealthDataPipeline.shared.requestAuthorization { healthGranted = $0 }
+            HealthDataPipeline.shared.requestAuthorization {
+                healthGranted = $0
+                updateHealthGranted()
+            }
         } else { showSettingsAlert = true }
     }
 


### PR DESCRIPTION
## Summary
- fix health permission toggle not reflecting actual status
- check authorization using `getRequestStatusForAuthorization`

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project EnFlow.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ba8dfaa44832f829abb93d904837b