### PR TITLE
Adjust dark theme

### DIFF
--- a/EnFlow/ContentView.swift
+++ b/EnFlow/ContentView.swift
@@ -27,6 +27,8 @@ struct ContentView: View {
 #if os(macOS)
             .navigationSplitViewColumnWidth(min: 180, ideal: 200)
 #endif
+            .scrollContentBackground(.hidden)
+            .enflowBackground()
             .toolbar {
 #if os(iOS)
                 ToolbarItem(placement: .navigationBarTrailing) {

--- a/EnFlow/EnFlowApp.swift
+++ b/EnFlow/EnFlowApp.swift
@@ -2,10 +2,17 @@
 // Entry Point for EnFlow – Energy Intelligence Platform
 
 import SwiftUI
+#if os(iOS)
+import UIKit
+#endif
 
 @main
 struct EnFlowApp: App {
     @AppStorage("didCompleteOnboarding") private var onboarded = false
+
+#if os(iOS)
+    init() { setupAppearance() }
+#endif
 
     var body: some Scene {
         WindowGroup {
@@ -14,7 +21,26 @@ struct EnFlowApp: App {
             } else {
                 OnboardingAndSettingsView()
             }
+            .preferredColorScheme(.dark)
         }
     }
+
+#if os(iOS)
+    private func setupAppearance() {
+        let nav = UINavigationBarAppearance()
+        nav.configureWithTransparentBackground()
+        nav.backgroundColor = UIColor(red: 0.05, green: 0.08, blue: 0.20, alpha: 0.8)
+        UINavigationBar.appearance().standardAppearance = nav
+        UINavigationBar.appearance().scrollEdgeAppearance = nav
+
+        let tab = UITabBarAppearance()
+        tab.configureWithTransparentBackground()
+        tab.backgroundColor = UIColor(red: 0.05, green: 0.08, blue: 0.20, alpha: 0.8)
+        UITabBar.appearance().standardAppearance = tab
+        if #available(iOS 15.0, *) {
+            UITabBar.appearance().scrollEdgeAppearance = tab
+        }
+    }
+#endif
 }
 

--- a/EnFlow/Views/OnboardingAndSettingsView.swift
+++ b/EnFlow/Views/OnboardingAndSettingsView.swift
@@ -61,6 +61,7 @@ struct OnboardingAndSettingsView: View {
                 // ─── About ───
                 aboutSection
             }
+            .scrollContentBackground(.hidden)
             .navigationTitle("Settings")
         }
         .enflowBackground()


### PR DESCRIPTION
## Summary
- make settings form background transparent
- enforce dark mode and tinted UI appearances
- ensure sample ContentView uses the EnFlow background

## Testing
- `swift test -c release` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685bab735c38832faee970e367cddb04