### PR TITLE
Fix Chart endpoint scaling

### DIFF
--- a/EnFlow/Views/TrendsView.swift
+++ b/EnFlow/Views/TrendsView.swift
@@ -372,17 +372,15 @@ Analyze correlations between the user's calendar events and their energy data. W
         if let lastA = summaries.last {
             PointMark(x: .value("Day", lastA.date), y: .value("Actual", lastA.overallEnergyScore))
                 .symbol(.circle)
-                .symbolSize(80)
+                .symbolSize(animatePulse ? 96 : 64)
                 .foregroundStyle(Color.yellow)
-                .scaleEffect(animatePulse ? 1.2 : 0.8)
                 .shadow(radius: 8)
         }
         if let lastF = forecastSummaries.last {
             PointMark(x: .value("Day", lastF.date), y: .value("Forecast", lastF.overallEnergyScore))
                 .symbol(.circle)
-                .symbolSize(80)
+                .symbolSize(animatePulse ? 96 : 64)
                 .foregroundStyle(Color.blue)
-                .scaleEffect(animatePulse ? 1.2 : 0.8)
                 .shadow(radius: 8)
         }
     }


### PR DESCRIPTION
## Summary
- fix `TrendsView` compile error by replacing `scaleEffect` with dynamic `symbolSize`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685bacb51fac832f9a0513398b351103