### PR TITLE
Fix preferredColorScheme compile error

### DIFF
--- a/EnFlow/EnFlowApp.swift
+++ b/EnFlow/EnFlowApp.swift
@@ -16,10 +16,12 @@ struct EnFlowApp: App {
 
     var body: some Scene {
         WindowGroup {
-            if onboarded {
-                MainShellView()
-            } else {
-                OnboardingAndSettingsView()
+            Group {
+                if onboarded {
+                    MainShellView()
+                } else {
+                    OnboardingAndSettingsView()
+                }
             }
             .preferredColorScheme(.dark)
         }


### PR DESCRIPTION
## Summary
- wrap onboarding conditional in a `Group` before applying `.preferredColorScheme(.dark)`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685bade01dc0832f98f38352e36bbc6e