### PR TITLE
Disable future energy display

### DIFF
--- a/EnFlow/Views/Components/DayView.swift
+++ b/EnFlow/Views/Components/DayView.swift
@@ -14,7 +14,7 @@ struct DayView: View {
   @State private var events: [CalendarEvent] = []
   @State private var forecast: [Double] = Array(repeating: 0.5, count: 24)
   @State private var parts = EnergyForecastModel.EnergyParts(morning: 0, afternoon: 0, evening: 0)
-  @State private var overallScore: Double = 0
+  @State private var overallScore: Double? = nil
   @State private var page = 0  // 0 = schedule, 1 = overview
 
   private let calendar = Calendar.current
@@ -112,7 +112,7 @@ struct DayView: View {
     ScrollView {
       VStack(spacing: 24) {
         HStack(alignment: .center, spacing: 70) {
-          EnergyRingView(score: overallScore)
+          EnergyRingView(score: overallScore, summaryDate: currentDate)
             .frame(width: 100, height: 100)
           VStack(alignment: .center, spacing: 12) {
             labeledMiniRing(title: "Morning", value: parts.morning)
@@ -133,7 +133,7 @@ struct DayView: View {
     ScrollView {
       VStack(spacing: 85) {
 
-        EnergyRingView(score: overallScore)
+        EnergyRingView(score: overallScore, summaryDate: currentDate)
           .frame(width: 100, height: 100)
 
         ThreePartForecastView(parts: parts)
@@ -331,7 +331,12 @@ struct DayView: View {
       healthEvents: healthList,
       calendarEvents: dayEvents)
     forecast = summary.hourlyWaveform
-    overallScore = summary.overallEnergyScore
+    let today = calendar.startOfDay(for: Date())
+    if currentDate > today || summary.coverageRatio < 0.3 {
+      overallScore = nil
+    } else {
+      overallScore = summary.overallEnergyScore
+    }
 
     func avg(_ slice: ArraySlice<Double>) -> Double {
       slice.reduce(0, +) / Double(slice.count) * 100

--- a/EnFlow/Views/DashboardView.swift
+++ b/EnFlow/Views/DashboardView.swift
@@ -97,7 +97,7 @@ struct DashboardView: View {
         if let summary = todaySummary {
           VStack(spacing: 4) {
             EnergyRingView(
-              score: summary.overallEnergyScore,
+              score: missingTodayData ? nil : summary.overallEnergyScore,
               explainers: summary.explainers,
               summaryDate: summary.date
             )
@@ -150,26 +150,15 @@ struct DashboardView: View {
             .foregroundColor(.orange)
         }
 
-        // Forecast (dashed / desaturated)
-        if let score = tomorrowSummary?.overallEnergyScore {
-          EnergyRingView(
-            score: score,
-            dashed: true,
-            desaturate: true
-          )
-          .help("Forecast accuracy lower than today’s")
-          .frame(maxWidth: .infinity)
-        }
+        // No forecast for future days – show placeholder
+        EnergyRingView(
+          score: nil,
+          dashed: true,
+          desaturate: true
+        )
+        .frame(maxWidth: .infinity)
 
-        if let wave = tomorrowSummary?.hourlyWaveform {
-          VStack(alignment: .leading, spacing: 8) {
-            Text("24-Hour Energy Forecast")
-              .font(.headline)
-              .saturation(0.7)
-            EnergyLineChartView(values: wave)
-              .saturation(0.7)
-          }
-        }
+        // No hourly forecast shown
 
         if tomorrowConfidence > 0 && tomorrowConfidence < 0.4 {
           Text("⚠️ Forecast based on limited history – add more days of data for accuracy")
@@ -177,14 +166,7 @@ struct DashboardView: View {
             .foregroundColor(.orange)
         }
 
-        ThreePartForecastView(
-          parts: tomorrowParts,
-          dashed: true,
-          desaturate: true)
 
-        if let ctx = tomorrowCtx {
-          SuggestedPrioritiesView(context: ctx)
-        }
 
         Spacer(minLength: 60)
       }
@@ -292,11 +274,11 @@ struct DashboardView: View {
 
     await MainActor.run {
       todaySummary = tSummary
-      tomorrowSummary = tmSummary
+      tomorrowSummary = nil
       todayParts = tParts
-      tomorrowParts = tmParts
+      tomorrowParts = EnergyParts(morning: 0, afternoon: 0, evening: 0)
       todayCtx = tCtx
-      tomorrowCtx = tmCtx
+      tomorrowCtx = nil
       stepsToday = steps
       isLoading = false
       missingTodayData = noToday


### PR DESCRIPTION
## Summary
- support optional energy scores in `EnergyRingView`
- show placeholder rings when no data or future date in `DashboardView` and `DayView`
- suppress gradients for future days in week and month calendars
- hide forecast visuals for days beyond today

## Testing
- `xcodebuild -list -project EnFlow.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bbc383190832fa0ee8d59f329bcd9