### PR TITLE
Fix missing return in EnergyRingView status getter

### DIFF
--- a/EnFlow/Views/Components/EnergyRingView.swift
+++ b/EnFlow/Views/Components/EnergyRingView.swift
@@ -26,10 +26,14 @@ struct EnergyRingView: View {
     private var status: String {
         guard let score else { return "N/A" }
         switch score {
-        case 0..<50  : "LOW"
-        case 50..<80 : "MODERATE"
-        case 90..<100: "SUPERCHARGED"
-        default      : "HIGH"
+        case 0..<50:
+            return "LOW"
+        case 50..<80:
+            return "MODERATE"
+        case 90..<100:
+            return "SUPERCHARGED"
+        default:
+            return "HIGH"
         }
     }
     private var glowStrength: Double { isForecast ? 0 : (score ?? 0) / 100 }


### PR DESCRIPTION
## Summary
- fix `status` computed property to return string values

## Testing
- `xcodebuild -project EnFlow.xcodeproj -scheme EnFlow -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc0b8dd90832f842ee57e615c37e0