### PR TITLE
Fix energy chip background style

### DIFF
--- a/EnFlow/Views/Components/WeekCalendarView.swift
+++ b/EnFlow/Views/Components/WeekCalendarView.swift
@@ -209,7 +209,13 @@ struct WeekCalendarView: View {
             .font(.caption2.bold())
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
-            .background(score != nil ? ColorPalette.gradient(for: score!) : Color.gray.opacity(0.3))
+            .background {
+                if let score {
+                    ColorPalette.gradient(for: score)
+                } else {
+                    Color.gray.opacity(0.3)
+                }
+            }
             .clipShape(Capsule())
     }
 


### PR DESCRIPTION
## Summary
- fix mismatched ternary result types in `energyChip` by using a background view builder

## Testing
- `swift test` *(fails: no `Package.swift` found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc192ce78832f85d33e7186e4da28