### PR TITLE
Fix unicode escapes in JSONFormatter

### DIFF
--- a/EnFlow/Utilities/JSONFormatter.swift
+++ b/EnFlow/Utilities/JSONFormatter.swift
@@ -12,8 +12,8 @@ enum JSONFormatter {
 
         // Normalize curly quotes that GPT might emit
         cleaned = cleaned
-            .replacingOccurrences(of: "\u201c", with: "\"")
-            .replacingOccurrences(of: "\u201d", with: "\"")
+            .replacingOccurrences(of: "\u{201C}", with: "\"")
+            .replacingOccurrences(of: "\u{201D}", with: "\"")
 
         guard let data = cleaned.data(using: .utf8),
               let obj = try? JSONSerialization.jsonObject(with: data, options: []),


### PR DESCRIPTION
## Summary
- fix invalid unicode escape sequences in `JSONFormatter`

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc6efbda8832fa36c7a291998118a