### PR TITLE
Improve GPT weekly summary formatting

### DIFF
--- a/EnFlow/Utilities/WeeklySummaryFormatter.swift
+++ b/EnFlow/Utilities/WeeklySummaryFormatter.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+enum WeeklySummaryFormatter {
+    private struct Summary: Decodable {
+        struct Section: Decodable { let title: String; let content: String }
+        struct Event: Decodable { let title: String; let date: String }
+        let sections: [Section]
+        let events: [Event]
+    }
+
+    static func format(from raw: String) -> String {
+        var cleaned = raw
+            .replacingOccurrences(of: "```json", with: "")
+            .replacingOccurrences(of: "```", with: "")
+            .replacingOccurrences(of: "\u{201C}", with: "\"")
+            .replacingOccurrences(of: "\u{201D}", with: "\"")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard let data = cleaned.data(using: .utf8),
+              let summary = try? JSONDecoder().decode(Summary.self, from: data) else {
+            return cleaned
+        }
+
+        var lines: [String] = []
+        for section in summary.sections {
+            lines.append("\u2022 \(section.title): \(section.content)")
+        }
+
+        if !summary.events.isEmpty {
+            lines.append("")
+            lines.append("Events:")
+            let dfIn = ISO8601DateFormatter()
+            let dfOut = DateFormatter(); dfOut.dateStyle = .medium
+            for event in summary.events {
+                if let date = dfIn.date(from: event.date) {
+                    lines.append("- \(dfOut.string(from: date)): \(event.title)")
+                } else {
+                    lines.append("- \(event.date): \(event.title)")
+                }
+            }
+        }
+
+        return lines.joined(separator: "\n")
+    }
+}

--- a/EnFlow/Views/TrendsView.swift
+++ b/EnFlow/Views/TrendsView.swift
@@ -212,7 +212,7 @@ Analyze correlations between the user's calendar events and their energy data. W
                 prompt: prompt,
                 cacheId: "WeeklyJSON.\(period.rawValue)"
             )
-            gptSummary = JSONFormatter.pretty(from: raw)
+            gptSummary = WeeklySummaryFormatter.format(from: raw)
         } catch {
             gptSummary = "{ \"error\": \"Unable to load summary\" }"
         }

--- a/EnFlowTests/EnFlowTests.swift
+++ b/EnFlowTests/EnFlowTests.swift
@@ -24,4 +24,13 @@ struct EnFlowTests {
         #expect(pretty.contains("\"a\""))
     }
 
+    @Test func weeklySummaryFormatterProducesBullets() throws {
+        let raw = "{" +
+            "\"sections\":[{\"title\":\"T\",\"content\":\"C\"}]," +
+            "\"events\":[{\"title\":\"E\",\"date\":\"2025-06-25\"}]}"
+        let text = WeeklySummaryFormatter.format(from: raw)
+        #expect(text.contains("\u2022 T: C"))
+        #expect(text.contains("E"))
+    }
+
 }


### PR DESCRIPTION
## Summary
- add `WeeklySummaryFormatter` to transform GPT JSON into readable bullets
- use new formatter in `TrendsView` when loading the weekly summary
- test the new formatter logic

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685c67568a84832f9ff6826c583c199a