### PR TITLE
Add user profile support

### DIFF
--- a/EnFlow/Models/EnergyForecastModel.swift
+++ b/EnFlow/Models/EnergyForecastModel.swift
@@ -49,7 +49,8 @@ final class EnergyForecastModel: ObservableObject {
   func forecast(
     for date: Date,
     health: [HealthEvent],
-    events: [CalendarEvent]
+    events: [CalendarEvent],
+    profile: UserProfile? = nil
   ) -> DayEnergyForecast? {
 
     if let cached = ForecastCache.shared.forecast(for: date) {
@@ -63,13 +64,26 @@ final class EnergyForecastModel: ObservableObject {
 
     guard let base = computeHistoricalBase(from: history) else { return nil }
 
-    var wave = circadianBoost.map { max(0, min(1, base + $0)) }
+    var adjustedBase = base
+    if let p = profile {
+      adjustedBase += Double(p.exerciseFrequency - 3) * 0.01
+      adjustedBase -= Double(p.stressLevel - 3) * 0.02
+      if !p.mealsRegular { adjustedBase -= 0.03 }
+      adjustedBase = min(max(adjustedBase, 0), 1)
+    }
+
+    var wave = circadian(for: profile).map { max(0, min(1, adjustedBase + $0)) }
     for ev in events {
       guard let delta = ev.energyDelta else { continue }
       let hr = calendar.component(.hour, from: ev.startTime)
       if hr >= 0 && hr < 24 {
         wave[hr] = max(0, min(1, wave[hr] + delta))
       }
+    }
+
+    if let p = profile, p.caffeineIntakePerDay > 2 {
+      let dipHr = (calendar.component(.hour, from: p.caffeineTimeLastUsed) + 3) % 24
+      wave[dipHr] = max(0, wave[dipHr] - 0.1)
     }
 
     let score = wave.reduce(0, +) / Double(wave.count) * 100.0
@@ -94,10 +108,11 @@ final class EnergyForecastModel: ObservableObject {
   func threePartEnergy(
     for date: Date,
     health: [HealthEvent],
-    events: [CalendarEvent]
+    events: [CalendarEvent],
+    profile: UserProfile? = nil
   ) -> EnergyParts? {
 
-    guard let wave = forecast(for: date, health: health, events: events)?.values else { return nil }
+    guard let wave = forecast(for: date, health: health, events: events, profile: profile)?.values else { return nil }
     func avg(_ s: ArraySlice<Double>) -> Double { s.reduce(0, +) / Double(s.count) * 100.0 }
     return EnergyParts(
       morning: avg(wave[0..<8]),
@@ -154,4 +169,18 @@ final class EnergyForecastModel: ObservableObject {
     -0.04, -0.03, 0.00, 0.08, 0.12,  // 15-19
     0.10, 0.05, 0.00, -0.04,  // 20-23
   ]
+
+  private func circadian(for profile: UserProfile?) -> [Double] {
+    guard let p = profile else { return circadianBoost }
+    let wake = calendar.component(.hour, from: p.typicalWakeTime)
+    var shift = wake - 7
+    switch p.chronotype {
+    case .morning: shift -= 1
+    case .evening: shift += 1
+    default: break
+    }
+    let n = circadianBoost.count
+    let offset = ((shift % n) + n) % n
+    return Array(circadianBoost[offset..<n] + circadianBoost[0..<offset])
+  }
 }

--- a/EnFlow/Models/UnifiedEnergyModel.swift
+++ b/EnFlow/Models/UnifiedEnergyModel.swift
@@ -16,7 +16,8 @@ final class UnifiedEnergyModel {
     /// forecasted future energy when appropriate.
     func summary(for date: Date,
                  healthEvents: [HealthEvent],
-                 calendarEvents: [CalendarEvent]) -> DayEnergySummary {
+                 calendarEvents: [CalendarEvent],
+                 profile: UserProfile? = nil) -> DayEnergySummary {
 
         let summary = summaryEngine.summarize(day: date,
                                               healthEvents: healthEvents,
@@ -24,7 +25,8 @@ final class UnifiedEnergyModel {
 
         guard let forecast = forecastModel.forecast(for: date,
                                                     health: healthEvents,
-                                                    events: calendarEvents) else {
+                                                    events: calendarEvents,
+                                                    profile: profile) else {
             return summary
         }
         cache.saveForecast(forecast)

--- a/EnFlow/Models/UserProfile.swift
+++ b/EnFlow/Models/UserProfile.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+struct UserProfile: Codable, Equatable {
+    enum Chronotype: String, CaseIterable, Identifiable, Codable {
+        case morning
+        case intermediate
+        case evening
+        var id: String { rawValue }
+    }
+
+    var caffeineIntakePerDay: Int
+    var caffeineTimeLastUsed: Date
+    var exerciseFrequency: Int
+    var typicalWakeTime: Date
+    var typicalSleepTime: Date
+    var usesSleepAid: Bool
+    var screensBeforeBed: Bool
+    var mealsRegular: Bool
+    var stressLevel: Int
+    var chronotype: Chronotype
+    var lastUpdated: Date
+    var notes: String?
+}
+
+extension UserProfile {
+    static var `default`: UserProfile {
+        let cal = Calendar.current
+        let wake = cal.date(bySettingHour: 7, minute: 0, second: 0, of: Date())!
+        let sleep = cal.date(bySettingHour: 23, minute: 0, second: 0, of: Date())!
+        return UserProfile(
+            caffeineIntakePerDay: 0,
+            caffeineTimeLastUsed: wake,
+            exerciseFrequency: 3,
+            typicalWakeTime: wake,
+            typicalSleepTime: sleep,
+            usesSleepAid: false,
+            screensBeforeBed: true,
+            mealsRegular: true,
+            stressLevel: 3,
+            chronotype: .intermediate,
+            lastUpdated: Date(),
+            notes: nil
+        )
+    }
+
+    func debugSummary() -> String {
+        let fmt = DateFormatter()
+        fmt.dateFormat = "h:mm a"
+        return "Caffeine: \(caffeineIntakePerDay)/day, last at \(fmt.string(from: caffeineTimeLastUsed)). " +
+        "Wake \(fmt.string(from: typicalWakeTime)), Sleep \(fmt.string(from: typicalSleepTime)), " +
+        "Exercise \(exerciseFrequency)x/week, Stress \(stressLevel)/5, Chronotype \(chronotype.rawValue)."
+    }
+}

--- a/EnFlow/Models/UserProfileStore.swift
+++ b/EnFlow/Models/UserProfileStore.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+enum UserProfileStore {
+    private static var fileURL: URL {
+        let dir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        return dir.appendingPathComponent("UserProfile.json")
+    }
+
+    static func load() -> UserProfile {
+        guard let data = try? Data(contentsOf: fileURL),
+              let profile = try? JSONDecoder().decode(UserProfile.self, from: data) else {
+            return UserProfile.default
+        }
+        return profile
+    }
+
+    static func save(_ profile: UserProfile) {
+        if let data = try? JSONEncoder().encode(profile) {
+            try? data.write(to: fileURL, options: [.atomic])
+        }
+    }
+}

--- a/EnFlow/Views/Components/MonthCalendarView.swift
+++ b/EnFlow/Views/Components/MonthCalendarView.swift
@@ -234,13 +234,15 @@ struct MonthCalendarView: View {
 
         let today = calendar.startOfDay(for: Date())
 
-        for date in monthDates where calendar.isDate(date, equalTo: displayMonth, toGranularity: .month) {
-            if date > today { continue }
-            let dayHealth = allHealth.filter { calendar.isDate($0.date, inSameDayAs: date) }
-            let dayEvents = allEvents.filter { calendar.isDate($0.startTime, inSameDayAs: date) }
+       for date in monthDates where calendar.isDate(date, equalTo: displayMonth, toGranularity: .month) {
+           if date > today { continue }
+           let dayHealth = allHealth.filter { calendar.isDate($0.date, inSameDayAs: date) }
+           let dayEvents = allEvents.filter { calendar.isDate($0.startTime, inSameDayAs: date) }
+            let profile = UserProfileStore.load()
             let summary = UnifiedEnergyModel.shared.summary(for: date,
                                                            healthEvents: dayHealth,
-                                                           calendarEvents: dayEvents)
+                                                           calendarEvents: dayEvents,
+                                                           profile: profile)
             if summary.coverageRatio >= 0.3 {
                 results[date] = summary.overallEnergyScore
             }

--- a/EnFlow/Views/Components/WeekCalendarView.swift
+++ b/EnFlow/Views/Components/WeekCalendarView.swift
@@ -272,10 +272,12 @@ struct WeekCalendarView: View {
                     matrix[d] = Array(repeating: nil, count: hours.count)
                 } else {
                     let dayHealth = health.filter { calendar.isDate($0.date, inSameDayAs: day) }
-                    let dayEvents = allEvents.filter { calendar.isDate($0.startTime, inSameDayAs: day) }
+                   let dayEvents = allEvents.filter { calendar.isDate($0.startTime, inSameDayAs: day) }
+                    let profile = UserProfileStore.load()
                     let summary = UnifiedEnergyModel.shared.summary(for: day,
                                                                   healthEvents: dayHealth,
-                                                                  calendarEvents: dayEvents)
+                                                                  calendarEvents: dayEvents,
+                                                                  profile: profile)
                     if summary.coverageRatio < 0.3 {
                         matrix[d] = Array(repeating: nil, count: hours.count)
                     } else {

--- a/EnFlow/Views/DashboardView.swift
+++ b/EnFlow/Views/DashboardView.swift
@@ -217,20 +217,25 @@ struct DashboardView: View {
     let eventsToday = await CalendarDataPipeline.shared.fetchEvents(for: today)
     let eventsTomorrow = await CalendarDataPipeline.shared.fetchEvents(for: tomorrow)
 
+    let profile = UserProfileStore.load()
+
     // Daily summaries blended with forecast
     let tSummary = UnifiedEnergyModel.shared.summary(
       for: today,
       healthEvents: healthList,
-      calendarEvents: eventsToday)
+      calendarEvents: eventsToday,
+      profile: profile)
     let tmSummary = UnifiedEnergyModel.shared.summary(
       for: tomorrow,
       healthEvents: healthList,
-      calendarEvents: eventsTomorrow)
+      calendarEvents: eventsTomorrow,
+      profile: profile)
     let forecastConf =
       EnergyForecastModel().forecast(
         for: tomorrow,
         health: healthList,
-        events: eventsTomorrow)?.confidenceScore ?? 0
+        events: eventsTomorrow,
+        profile: profile)?.confidenceScore ?? 0
 
     let todayHealth = healthList.first { cal.isDate($0.date, inSameDayAs: today) }
     let tomorrowHealth = healthList.first { cal.isDate($0.date, inSameDayAs: tomorrow) }

--- a/EnFlow/Views/MainShellView.swift
+++ b/EnFlow/Views/MainShellView.swift
@@ -26,8 +26,8 @@ struct MainShellView: View {
                 NavigationView { TrendsView() }
                     .tabItem { Label("Trends", systemImage: "chart.bar.fill") }
 
-                NavigationView { DataView() }
-                    .tabItem { Label("Data", systemImage: "list.bullet.rectangle") }
+                NavigationView { UserProfileSummaryView() }
+                    .tabItem { Label("User", systemImage: "person.crop.circle") }
             }
             .tint(accent)
             .enflowBackground()
@@ -37,7 +37,7 @@ struct MainShellView: View {
                     NavigationLink(destination: DashboardView())      { Label("Dashboard", systemImage: "waveform.path.ecg") }
                     NavigationLink(destination: EnergyCalendarView()) { Label("Calendar",  systemImage: "calendar") }
                     NavigationLink(destination: TrendsView())         { Label("Trends",    systemImage: "chart.bar.fill") }
-                    NavigationLink(destination: DataView())           { Label("Data",      systemImage: "list.bullet.rectangle") }
+                    NavigationLink(destination: UserProfileSummaryView()) { Label("User", systemImage: "person.crop.circle") }
                 }
                 .listStyle(.sidebar)
                 .tint(accent)

--- a/EnFlow/Views/TrendsView.swift
+++ b/EnFlow/Views/TrendsView.swift
@@ -278,12 +278,13 @@ Analyze correlations between the user's calendar events and their energy data. W
             let h = healthList.filter { cal.isDate($0.date, inSameDayAs: day) }
             let ev = allEvents.filter { cal.isDate($0.startTime, inSameDayAs: day) }
 
-            let summary = UnifiedEnergyModel.shared.summary(for: day, healthEvents: h, calendarEvents: ev)
+            let profile = UserProfileStore.load()
+            let summary = UnifiedEnergyModel.shared.summary(for: day, healthEvents: h, calendarEvents: ev, profile: profile)
             actual.append(summary)
 
             var fWave = ForecastCache.shared.forecast(for: day)?.values
             if fWave == nil {
-                if let res = EnergyForecastModel().forecast(for: day, health: h, events: ev)?.values {
+                if let res = EnergyForecastModel().forecast(for: day, health: h, events: ev, profile: profile)?.values {
                     fWave = res
                     ForecastCache.shared.saveForecast(DayEnergyForecast(date: day,
                                                                      values: res,

--- a/EnFlow/Views/UserProfileQuizView.swift
+++ b/EnFlow/Views/UserProfileQuizView.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+struct UserProfileQuizView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var profile: UserProfile = UserProfileStore.load()
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section("Sleep") {
+                    DatePicker("Wake Time", selection: $profile.typicalWakeTime, displayedComponents: .hourAndMinute)
+                    DatePicker("Sleep Time", selection: $profile.typicalSleepTime, displayedComponents: .hourAndMinute)
+                    Toggle("Use Sleep Aid", isOn: $profile.usesSleepAid)
+                    Toggle("Screens Before Bed", isOn: $profile.screensBeforeBed)
+                    Toggle("Regular Meals", isOn: $profile.mealsRegular)
+                    Picker("Chronotype", selection: $profile.chronotype) {
+                        ForEach(UserProfile.Chronotype.allCases) { c in
+                            Text(c.rawValue.capitalized).tag(c)
+                        }
+                    }
+                }
+
+                Section("Caffeine") {
+                    Stepper("Cups per Day: \(profile.caffeineIntakePerDay)", value: $profile.caffeineIntakePerDay, in: 0...10)
+                    DatePicker("Last Caffeine", selection: $profile.caffeineTimeLastUsed, displayedComponents: .hourAndMinute)
+                }
+
+                Section("Activity") {
+                    Stepper("Exercise per Week: \(profile.exerciseFrequency)", value: $profile.exerciseFrequency, in: 0...14)
+                    Picker("Stress Level", selection: $profile.stressLevel) {
+                        ForEach(1...5, id: \.self) { v in Text("\(v)").tag(v) }
+                    }
+                }
+
+                Section("Notes") {
+                    TextEditor(text: Binding(get: { profile.notes ?? "" }, set: { profile.notes = $0 }))
+                        .frame(minHeight: 80)
+                }
+            }
+            .navigationTitle("Your Habits")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") { save() }
+                }
+                ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
+            }
+        }
+    }
+
+    private func save() {
+        profile.lastUpdated = Date()
+        UserProfileStore.save(profile)
+        dismiss()
+    }
+}

--- a/EnFlow/Views/UserProfileSummaryView.swift
+++ b/EnFlow/Views/UserProfileSummaryView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+struct UserProfileSummaryView: View {
+    @State private var profile: UserProfile = UserProfileStore.load()
+    @State private var showEdit = false
+
+    var body: some View {
+        List {
+            Section("Sleep") {
+                Text("Wake: \(time(profile.typicalWakeTime))")
+                Text("Sleep: \(time(profile.typicalSleepTime))")
+                Text("Chronotype: \(profile.chronotype.rawValue.capitalized)")
+            }
+            Section("Caffeine") {
+                Text("Cups per day: \(profile.caffeineIntakePerDay)")
+                Text("Last at: \(time(profile.caffeineTimeLastUsed))")
+            }
+            Section("Activity") {
+                Text("Exercise per week: \(profile.exerciseFrequency)")
+                Text("Stress: \(profile.stressLevel)/5")
+            }
+            if let notes = profile.notes, !notes.isEmpty {
+                Section("Notes") { Text(notes) }
+            }
+            Section("Debug") { Text(profile.debugSummary()) }
+        }
+        .navigationTitle("User Profile")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("Edit Profile") { showEdit = true }
+            }
+        }
+        .sheet(isPresented: $showEdit, onDismiss: { profile = UserProfileStore.load() }) {
+            UserProfileQuizView()
+        }
+    }
+
+    private func time(_ d: Date) -> String {
+        let fmt = DateFormatter()
+        fmt.timeStyle = .short
+        return fmt.string(from: d)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ EnFlow uses your calendar and Health data:
 
 You can grant permissions during onboarding or later from the Settings screen.
 
+## Editing Your User Profile
+
+From the **User** tab you can view your saved habits and tap **Edit Profile** to update them. The quiz collects sleep, caffeine and activity routines. Your answers are stored locally in `UserProfile.json` and influence energy forecasts. Revisit the quiz anytime to keep recommendations fresh.
+
 ## Testing & Troubleshooting
 
 - Run unit and UI tests from Xcode with **⌘U** or via `xcodebuild test`.


### PR DESCRIPTION
## Summary
- add `UserProfile` model and persistence store
- implement profile quiz and summary views
- rename Data tab to User
- wire profile into forecast model heuristics and UnifiedEnergyModel
- document how to edit your profile

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c74e2ad18832fbf7f3a5d95ac6e60