### PR TITLE
Add user profile support

### DIFF
--- a/EnFlow/Models/UnifiedEnergyModel.swift
+++ b/EnFlow/Models/UnifiedEnergyModel.swift
@@ -16,7 +16,8 @@ final class UnifiedEnergyModel {
     /// forecasted future energy when appropriate.
     func summary(for date: Date,
                  healthEvents: [HealthEvent],
-                 calendarEvents: [CalendarEvent]) -> DayEnergySummary {
+                 calendarEvents: [CalendarEvent],
+                 profile: UserProfile? = nil) -> DayEnergySummary {
 
         let summary = summaryEngine.summarize(day: date,
                                               healthEvents: healthEvents,
@@ -24,7 +25,8 @@ final class UnifiedEnergyModel {
 
         guard let forecast = forecastModel.forecast(for: date,
                                                     health: healthEvents,
-                                                    events: calendarEvents) else {
+                                                    events: calendarEvents,
+                                                    profile: profile) else {
             return summary
         }
         cache.saveForecast(forecast)

--- a/EnFlow/Models/UserProfile.swift
+++ b/EnFlow/Models/UserProfile.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+struct UserProfile: Codable, Equatable {
+    enum Chronotype: String, CaseIterable, Identifiable, Codable {
+        case morning
+        case intermediate
+        case evening
+        var id: String { rawValue }
+    }
+
+    var caffeineMgPerDay: Int
+    var caffeineMorning: Bool
+    var caffeineAfternoon: Bool
+    var caffeineEvening: Bool
+    var exerciseFrequency: Int
+    var typicalWakeTime: Date
+    var typicalSleepTime: Date
+    var usesSleepAid: Bool
+    var screensBeforeBed: Bool
+    var mealsRegular: Bool
+    var chronotype: Chronotype
+    var lastUpdated: Date
+    var notes: String?
+}
+
+extension UserProfile {
+    static var `default`: UserProfile {
+        let cal = Calendar.current
+        let wake = cal.date(bySettingHour: 7, minute: 0, second: 0, of: Date())!
+        let sleep = cal.date(bySettingHour: 23, minute: 0, second: 0, of: Date())!
+        return UserProfile(
+            caffeineMgPerDay: 0,
+            caffeineMorning: false,
+            caffeineAfternoon: false,
+            caffeineEvening: false,
+            exerciseFrequency: 3,
+            typicalWakeTime: wake,
+            typicalSleepTime: sleep,
+            usesSleepAid: false,
+            screensBeforeBed: true,
+            mealsRegular: true,
+            chronotype: .intermediate,
+            lastUpdated: Date(),
+            notes: nil
+        )
+    }
+
+    func debugSummary() -> String {
+        let fmt = DateFormatter()
+        fmt.dateFormat = "h:mm a"
+        let caffeineTimes = [
+            caffeineMorning ? "morning" : nil,
+            caffeineAfternoon ? "afternoon" : nil,
+            caffeineEvening ? "evening" : nil
+        ].compactMap { $0 }.joined(separator: ", ")
+        return "Caffeine: \(caffeineMgPerDay) mg/day (\(caffeineTimes)). " +
+        "Wake \(fmt.string(from: typicalWakeTime)), Sleep \(fmt.string(from: typicalSleepTime)), " +
+        "Exercise \(exerciseFrequency)x/week, Chronotype \(chronotype.rawValue)."
+    }
+}

--- a/EnFlow/Models/UserProfileStore.swift
+++ b/EnFlow/Models/UserProfileStore.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+enum UserProfileStore {
+    private static var fileURL: URL {
+        let dir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        return dir.appendingPathComponent("UserProfile.json")
+    }
+
+    static func load() -> UserProfile {
+        guard let data = try? Data(contentsOf: fileURL),
+              let profile = try? JSONDecoder().decode(UserProfile.self, from: data) else {
+            return UserProfile.default
+        }
+        return profile
+    }
+
+    static func save(_ profile: UserProfile) {
+        if let data = try? JSONEncoder().encode(profile) {
+            try? data.write(to: fileURL, options: [.atomic])
+        }
+    }
+}

--- a/EnFlow/Views/Components/MonthCalendarView.swift
+++ b/EnFlow/Views/Components/MonthCalendarView.swift
@@ -234,13 +234,15 @@ struct MonthCalendarView: View {
 
         let today = calendar.startOfDay(for: Date())
 
-        for date in monthDates where calendar.isDate(date, equalTo: displayMonth, toGranularity: .month) {
-            if date > today { continue }
-            let dayHealth = allHealth.filter { calendar.isDate($0.date, inSameDayAs: date) }
-            let dayEvents = allEvents.filter { calendar.isDate($0.startTime, inSameDayAs: date) }
+       for date in monthDates where calendar.isDate(date, equalTo: displayMonth, toGranularity: .month) {
+           if date > today { continue }
+           let dayHealth = allHealth.filter { calendar.isDate($0.date, inSameDayAs: date) }
+           let dayEvents = allEvents.filter { calendar.isDate($0.startTime, inSameDayAs: date) }
+            let profile = UserProfileStore.load()
             let summary = UnifiedEnergyModel.shared.summary(for: date,
                                                            healthEvents: dayHealth,
-                                                           calendarEvents: dayEvents)
+                                                           calendarEvents: dayEvents,
+                                                           profile: profile)
             if summary.coverageRatio >= 0.3 {
                 results[date] = summary.overallEnergyScore
             }

--- a/EnFlow/Views/Components/WeekCalendarView.swift
+++ b/EnFlow/Views/Components/WeekCalendarView.swift
@@ -272,10 +272,12 @@ struct WeekCalendarView: View {
                     matrix[d] = Array(repeating: nil, count: hours.count)
                 } else {
                     let dayHealth = health.filter { calendar.isDate($0.date, inSameDayAs: day) }
-                    let dayEvents = allEvents.filter { calendar.isDate($0.startTime, inSameDayAs: day) }
+                   let dayEvents = allEvents.filter { calendar.isDate($0.startTime, inSameDayAs: day) }
+                    let profile = UserProfileStore.load()
                     let summary = UnifiedEnergyModel.shared.summary(for: day,
                                                                   healthEvents: dayHealth,
-                                                                  calendarEvents: dayEvents)
+                                                                  calendarEvents: dayEvents,
+                                                                  profile: profile)
                     if summary.coverageRatio < 0.3 {
                         matrix[d] = Array(repeating: nil, count: hours.count)
                     } else {

--- a/EnFlow/Views/DashboardView.swift
+++ b/EnFlow/Views/DashboardView.swift
@@ -217,20 +217,25 @@ struct DashboardView: View {
     let eventsToday = await CalendarDataPipeline.shared.fetchEvents(for: today)
     let eventsTomorrow = await CalendarDataPipeline.shared.fetchEvents(for: tomorrow)
 
+    let profile = UserProfileStore.load()
+
     // Daily summaries blended with forecast
     let tSummary = UnifiedEnergyModel.shared.summary(
       for: today,
       healthEvents: healthList,
-      calendarEvents: eventsToday)
+      calendarEvents: eventsToday,
+      profile: profile)
     let tmSummary = UnifiedEnergyModel.shared.summary(
       for: tomorrow,
       healthEvents: healthList,
-      calendarEvents: eventsTomorrow)
+      calendarEvents: eventsTomorrow,
+      profile: profile)
     let forecastConf =
       EnergyForecastModel().forecast(
         for: tomorrow,
         health: healthList,
-        events: eventsTomorrow)?.confidenceScore ?? 0
+        events: eventsTomorrow,
+        profile: profile)?.confidenceScore ?? 0
 
     let todayHealth = healthList.first { cal.isDate($0.date, inSameDayAs: today) }
     let tomorrowHealth = healthList.first { cal.isDate($0.date, inSameDayAs: tomorrow) }

--- a/EnFlow/Views/MainShellView.swift
+++ b/EnFlow/Views/MainShellView.swift
@@ -26,8 +26,8 @@ struct MainShellView: View {
                 NavigationView { TrendsView() }
                     .tabItem { Label("Trends", systemImage: "chart.bar.fill") }
 
-                NavigationView { DataView() }
-                    .tabItem { Label("Data", systemImage: "list.bullet.rectangle") }
+                NavigationView { UserProfileSummaryView() }
+                    .tabItem { Label("User", systemImage: "person.crop.circle") }
             }
             .tint(accent)
             .enflowBackground()
@@ -37,7 +37,7 @@ struct MainShellView: View {
                     NavigationLink(destination: DashboardView())      { Label("Dashboard", systemImage: "waveform.path.ecg") }
                     NavigationLink(destination: EnergyCalendarView()) { Label("Calendar",  systemImage: "calendar") }
                     NavigationLink(destination: TrendsView())         { Label("Trends",    systemImage: "chart.bar.fill") }
-                    NavigationLink(destination: DataView())           { Label("Data",      systemImage: "list.bullet.rectangle") }
+                    NavigationLink(destination: UserProfileSummaryView()) { Label("User", systemImage: "person.crop.circle") }
                 }
                 .listStyle(.sidebar)
                 .tint(accent)

--- a/EnFlow/Views/TrendsView.swift
+++ b/EnFlow/Views/TrendsView.swift
@@ -278,12 +278,13 @@ Analyze correlations between the user's calendar events and their energy data. W
             let h = healthList.filter { cal.isDate($0.date, inSameDayAs: day) }
             let ev = allEvents.filter { cal.isDate($0.startTime, inSameDayAs: day) }
 
-            let summary = UnifiedEnergyModel.shared.summary(for: day, healthEvents: h, calendarEvents: ev)
+            let profile = UserProfileStore.load()
+            let summary = UnifiedEnergyModel.shared.summary(for: day, healthEvents: h, calendarEvents: ev, profile: profile)
             actual.append(summary)
 
             var fWave = ForecastCache.shared.forecast(for: day)?.values
             if fWave == nil {
-                if let res = EnergyForecastModel().forecast(for: day, health: h, events: ev)?.values {
+                if let res = EnergyForecastModel().forecast(for: day, health: h, events: ev, profile: profile)?.values {
                     fWave = res
                     ForecastCache.shared.saveForecast(DayEnergyForecast(date: day,
                                                                      values: res,

--- a/EnFlow/Views/UserProfileQuizView.swift
+++ b/EnFlow/Views/UserProfileQuizView.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+struct UserProfileQuizView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var profile: UserProfile = UserProfileStore.load()
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section("Sleep") {
+                    DatePicker("Wake Time", selection: $profile.typicalWakeTime, displayedComponents: .hourAndMinute)
+                    DatePicker("Sleep Time", selection: $profile.typicalSleepTime, displayedComponents: .hourAndMinute)
+                    Toggle("Use Sleep Aid", isOn: $profile.usesSleepAid)
+                    Toggle("Screens Before Bed", isOn: $profile.screensBeforeBed)
+                    Toggle("Regular Meals", isOn: $profile.mealsRegular)
+                    Picker("Chronotype", selection: $profile.chronotype) {
+                        ForEach(UserProfile.Chronotype.allCases) { c in
+                            Text(c.rawValue.capitalized).tag(c)
+                        }
+                    }
+                }
+
+                Section("Caffeine") {
+                    Stepper("Total mg per Day: \(profile.caffeineMgPerDay)", value: $profile.caffeineMgPerDay, in: 0...1000, step: 50)
+                    VStack(alignment: .leading) {
+                        Toggle("Morning", isOn: $profile.caffeineMorning)
+                        Toggle("Afternoon", isOn: $profile.caffeineAfternoon)
+                        Toggle("Evening", isOn: $profile.caffeineEvening)
+                        Text("1 cup coffee ≈ 95 mg, 1 iced tea ≈ 45 mg")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+
+                Section("Activity") {
+                    Stepper("Exercise per Week: \(profile.exerciseFrequency)", value: $profile.exerciseFrequency, in: 0...14)
+                }
+
+                Section("Notes") {
+                    TextEditor(text: Binding(get: { profile.notes ?? "" }, set: { profile.notes = $0 }))
+                        .frame(minHeight: 80)
+                }
+            }
+            .navigationTitle("Your Habits")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") { save() }
+                }
+                ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
+            }
+        }
+    }
+
+    private func save() {
+        profile.lastUpdated = Date()
+        UserProfileStore.save(profile)
+        dismiss()
+    }
+}

--- a/EnFlow/Views/UserProfileSummaryView.swift
+++ b/EnFlow/Views/UserProfileSummaryView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+struct UserProfileSummaryView: View {
+    @State private var profile: UserProfile = UserProfileStore.load()
+    @State private var showEdit = false
+
+    var body: some View {
+        List {
+            Section("Sleep") {
+                Text("Wake: \(time(profile.typicalWakeTime))")
+                Text("Sleep: \(time(profile.typicalSleepTime))")
+                Text("Chronotype: \(profile.chronotype.rawValue.capitalized)")
+            }
+            Section("Caffeine") {
+                Text("\(profile.caffeineMgPerDay) mg/day")
+                Text(caffeineTimes(profile))
+            }
+            Section("Activity") {
+                Text("Exercise per week: \(profile.exerciseFrequency)")
+            }
+            if let notes = profile.notes, !notes.isEmpty {
+                Section("Notes") { Text(notes) }
+            }
+            Section("Debug") { Text(profile.debugSummary()) }
+            Section {
+                NavigationLink("Data") { DataView() }
+            }
+        }
+        .navigationTitle("User Profile")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("Edit Profile") { showEdit = true }
+            }
+        }
+        .sheet(isPresented: $showEdit, onDismiss: { profile = UserProfileStore.load() }) {
+            UserProfileQuizView()
+        }
+    }
+
+    private func time(_ d: Date) -> String {
+        let fmt = DateFormatter()
+        fmt.timeStyle = .short
+        return fmt.string(from: d)
+    }
+
+    private func caffeineTimes(_ p: UserProfile) -> String {
+        let parts = [
+            p.caffeineMorning ? "Morning" : nil,
+            p.caffeineAfternoon ? "Afternoon" : nil,
+            p.caffeineEvening ? "Evening" : nil
+        ].compactMap { $0 }
+        return parts.isEmpty ? "No set time" : parts.joined(separator: ", ")
+    }
+}

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ EnFlow uses your calendar and Health data:
 
 You can grant permissions during onboarding or later from the Settings screen.
 
+## Editing Your User Profile
+
+From the **User** tab you can view your saved habits and tap **Edit Profile** to update them. The quiz collects sleep, caffeine and activity routines. Your answers are stored locally in `UserProfile.json` and influence energy forecasts. Revisit the quiz anytime to keep recommendations fresh.
+
+The profile records your daily caffeine intake in milligrams. As a reminder, a cup of coffee is roughly 95&nbsp;mg of caffeine while an iced tea is around 45&nbsp;mg. Use the toggles to indicate if you typically consume caffeine in the morning, afternoon or evening. You can also open the **Data** page from the User tab to browse your recent HealthKit samples and calendar events. A switch on that screen lets you use simulated health data for testing.
+
 ## Testing & Troubleshooting
 
 - Run unit and UI tests from Xcode with **⌘U** or via `xcodebuild test`.


### PR DESCRIPTION
## Summary
- add `UserProfile` model and persistence store
- implement profile quiz and summary views
- rename Data tab to User
- wire profile into forecast model heuristics and UnifiedEnergyModel
- document how to edit your profile

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c74e2ad18832fbf7f3a5d95ac6e60