### PR TITLE
Adjust energy forecast markers

### DIFF
--- a/EnFlow/Views/Components/DailyEnergyForecastView.swift
+++ b/EnFlow/Views/Components/DailyEnergyForecastView.swift
@@ -34,7 +34,7 @@ struct DailyEnergyForecastView: View {
             ForEach(0..<count, id: \.self) { idx in
                 let x = width * CGFloat(idx) / CGFloat(max(count - 1, 1))
                 Text(hourLabel(startHour + idx))
-                    .font(.caption2)
+                    .font(.system(size: 8))
                     .foregroundColor(.secondary)
                     .position(x: x, y: height + 10)
             }
@@ -74,7 +74,7 @@ struct DailyEnergyForecastView: View {
             .formatted(.dateTime.hour(.defaultDigits(amPM: .abbreviated))) ?? "\(hour)h"
     }
 
-    private func significantPeaksAndTroughs(threshold: Double = 0.2) -> [Int] {
+    private func significantPeaksAndTroughs(threshold: Double = 0.15) -> [Int] {
         guard values.count > 2 else { return [] }
         var result: [Int] = []
         for i in 1..<(values.count - 1) {

--- a/EnFlow/Views/Components/DayView.swift
+++ b/EnFlow/Views/Components/DayView.swift
@@ -301,7 +301,7 @@ struct DayView: View {
 
   // MARK: ─ Peak/trough markers ───────────────────────────────
   private func significantPeaksAndTroughs(
-    threshold: Double = 0.2
+    threshold: Double = 0.15
   ) -> [(Int, Double)] {
     guard forecast.count == 24 else { return [] }
     var result: [(Int, Double)] = []


### PR DESCRIPTION
## Summary
- shrink hour labels on the daily forecast graph
- detect more peaks and troughs with a lower threshold

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685c7d1cf000832fac6889925a121949