### PR TITLE
Reset tab views to top

### DIFF
--- a/EnFlow/Views/DashboardView.swift
+++ b/EnFlow/Views/DashboardView.swift
@@ -37,6 +37,8 @@ struct DashboardView: View {
   @State private var isLoading = true
   @State private var stepsToday = 0
   @State private var selection = 0  // 0 = today • 1 = tomorrow
+  /// IDs used to recreate inactive pages so they reset scroll position
+  @State private var pageIDs: [Int: UUID] = [0: UUID(), 1: UUID()]
   @State private var missingTodayData = false
   @State private var missingTomorrowData = false
   @State private var tomorrowConfidence: Double = 0
@@ -46,8 +48,12 @@ struct DashboardView: View {
   // MARK: Root view ----------------------------------------------------------
   var body: some View {
     TabView(selection: $selection) {
-      todayPage.tag(0)
-      tomorrowPage.tag(1)
+      todayPage
+        .id(pageIDs[0]!)
+        .tag(0)
+      tomorrowPage
+        .id(pageIDs[1]!)
+        .tag(1)
     }
     .tabViewStyle(.page(indexDisplayMode: .never))
     .animation(.easeInOut, value: selection)
@@ -63,11 +69,16 @@ struct DashboardView: View {
       .padding(.trailing, 16)
       .padding(.top, pickerTop)
     }
-    // Soft haptic on tab switch
-    .onChange(of: selection) { _ in
+    // Soft haptic and reset inactive page on tab switch
+    .onChange(of: selection) { newValue in
       #if os(iOS)
         UIImpactFeedbackGenerator(style: .soft).impactOccurred()
       #endif
+      if newValue == 0 {
+        pageIDs[1] = UUID()
+      } else {
+        pageIDs[0] = UUID()
+      }
     }
 
     // Notch shim

--- a/EnFlow/Views/MainShellView.swift
+++ b/EnFlow/Views/MainShellView.swift
@@ -9,6 +9,10 @@ import SwiftUI
 
 struct MainShellView: View {
     @State private var showSettings = false
+    /// Active tab index
+    @State private var selection = 0
+    /// Unique IDs to force-reset scroll position when a tab is revisited
+    @State private var tabIDs: [Int: UUID] = [0: UUID(), 1: UUID(), 2: UUID(), 3: UUID()]
     private let accent = ColorPalette.color(for: 70)
 
     var body: some View {
@@ -16,18 +20,32 @@ struct MainShellView: View {
 
             // ───────── Main content (tabs) ─────────
             #if os(iOS)
-            TabView {
+            TabView(selection: $selection) {
                 NavigationView { DashboardView() }
+                    .id(tabIDs[0]!)
                     .tabItem { Label("Dashboard", systemImage: "waveform.path.ecg") }
+                    .tag(0)
 
                 NavigationView { CalendarRootView() }
+                    .id(tabIDs[1]!)
                     .tabItem { Label("Calendar", systemImage: "calendar") }
+                    .tag(1)
 
                 NavigationView { TrendsView() }
+                    .id(tabIDs[2]!)
                     .tabItem { Label("Trends", systemImage: "chart.bar.fill") }
+                    .tag(2)
 
                 NavigationView { UserProfileSummaryView() }
+                    .id(tabIDs[3]!)
                     .tabItem { Label("User", systemImage: "person.crop.circle") }
+                    .tag(3)
+            }
+            .onChange(of: selection) { newValue in
+                // Regenerate IDs for non-active tabs so they reset when revisited
+                for index in 0..<4 where index != newValue {
+                    tabIDs[index] = UUID()
+                }
             }
             .tint(accent)
             .enflowBackground()


### PR DESCRIPTION
## Summary
- ensure each main tab is recreated when reselected so scroll is reset
- make Dashboard view's Today/Tomorrow pages reset when switching

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685c7d6e39a0832fb3faeb980647cec0