### PR TITLE
Add Data page & update caffeine intake

### DIFF
--- a/EnFlow/Models/EnergyForecastModel.swift
+++ b/EnFlow/Models/EnergyForecastModel.swift
@@ -67,7 +67,6 @@ final class EnergyForecastModel: ObservableObject {
     var adjustedBase = base
     if let p = profile {
       adjustedBase += Double(p.exerciseFrequency - 3) * 0.01
-      adjustedBase -= Double(p.stressLevel - 3) * 0.02
       if !p.mealsRegular { adjustedBase -= 0.03 }
       adjustedBase = min(max(adjustedBase, 0), 1)
     }
@@ -81,9 +80,15 @@ final class EnergyForecastModel: ObservableObject {
       }
     }
 
-    if let p = profile, p.caffeineIntakePerDay > 2 {
-      let dipHr = (calendar.component(.hour, from: p.caffeineTimeLastUsed) + 3) % 24
-      wave[dipHr] = max(0, wave[dipHr] - 0.1)
+    if let p = profile, p.caffeineMgPerDay > 300 {
+      var dipHours: [Int] = []
+      if p.caffeineMorning     { dipHours.append(11) }
+      if p.caffeineAfternoon   { dipHours.append(18) }
+      if p.caffeineEvening     { dipHours.append(23) }
+      for h in dipHours {
+        let idx = h % 24
+        wave[idx] = max(0, wave[idx] - 0.1)
+      }
     }
 
     let score = wave.reduce(0, +) / Double(wave.count) * 100.0

--- a/EnFlow/Models/UserProfile.swift
+++ b/EnFlow/Models/UserProfile.swift
@@ -8,15 +8,16 @@ struct UserProfile: Codable, Equatable {
         var id: String { rawValue }
     }
 
-    var caffeineIntakePerDay: Int
-    var caffeineTimeLastUsed: Date
+    var caffeineMgPerDay: Int
+    var caffeineMorning: Bool
+    var caffeineAfternoon: Bool
+    var caffeineEvening: Bool
     var exerciseFrequency: Int
     var typicalWakeTime: Date
     var typicalSleepTime: Date
     var usesSleepAid: Bool
     var screensBeforeBed: Bool
     var mealsRegular: Bool
-    var stressLevel: Int
     var chronotype: Chronotype
     var lastUpdated: Date
     var notes: String?
@@ -28,15 +29,16 @@ extension UserProfile {
         let wake = cal.date(bySettingHour: 7, minute: 0, second: 0, of: Date())!
         let sleep = cal.date(bySettingHour: 23, minute: 0, second: 0, of: Date())!
         return UserProfile(
-            caffeineIntakePerDay: 0,
-            caffeineTimeLastUsed: wake,
+            caffeineMgPerDay: 0,
+            caffeineMorning: false,
+            caffeineAfternoon: false,
+            caffeineEvening: false,
             exerciseFrequency: 3,
             typicalWakeTime: wake,
             typicalSleepTime: sleep,
             usesSleepAid: false,
             screensBeforeBed: true,
             mealsRegular: true,
-            stressLevel: 3,
             chronotype: .intermediate,
             lastUpdated: Date(),
             notes: nil
@@ -46,8 +48,8 @@ extension UserProfile {
     func debugSummary() -> String {
         let fmt = DateFormatter()
         fmt.dateFormat = "h:mm a"
-        return "Caffeine: \(caffeineIntakePerDay)/day, last at \(fmt.string(from: caffeineTimeLastUsed)). " +
+        return "Caffeine: \(caffeineMgPerDay)mg/day (M:\(caffeineMorning), A:\(caffeineAfternoon), E:\(caffeineEvening)). " +
         "Wake \(fmt.string(from: typicalWakeTime)), Sleep \(fmt.string(from: typicalSleepTime)), " +
-        "Exercise \(exerciseFrequency)x/week, Stress \(stressLevel)/5, Chronotype \(chronotype.rawValue)."
+        "Exercise \(exerciseFrequency)x/week, Chronotype \(chronotype.rawValue)."
     }
 }

--- a/EnFlow/Views/UserProfileQuizView.swift
+++ b/EnFlow/Views/UserProfileQuizView.swift
@@ -21,15 +21,16 @@ struct UserProfileQuizView: View {
                 }
 
                 Section("Caffeine") {
-                    Stepper("Cups per Day: \(profile.caffeineIntakePerDay)", value: $profile.caffeineIntakePerDay, in: 0...10)
-                    DatePicker("Last Caffeine", selection: $profile.caffeineTimeLastUsed, displayedComponents: .hourAndMinute)
+                    Stepper("Daily Intake (mg): \(profile.caffeineMgPerDay)", value: $profile.caffeineMgPerDay, in: 0...1000, step: 10)
+                    Toggle("Morning", isOn: $profile.caffeineMorning)
+                    Toggle("Afternoon", isOn: $profile.caffeineAfternoon)
+                    Toggle("Evening", isOn: $profile.caffeineEvening)
+                    Text("e.g. 1 cup coffee ≈ 95 mg, 1 iced tea ≈ 40 mg")
+                        .font(.footnote).foregroundColor(.secondary)
                 }
 
                 Section("Activity") {
                     Stepper("Exercise per Week: \(profile.exerciseFrequency)", value: $profile.exerciseFrequency, in: 0...14)
-                    Picker("Stress Level", selection: $profile.stressLevel) {
-                        ForEach(1...5, id: \.self) { v in Text("\(v)").tag(v) }
-                    }
                 }
 
                 Section("Notes") {

--- a/EnFlow/Views/UserProfileSummaryView.swift
+++ b/EnFlow/Views/UserProfileSummaryView.swift
@@ -12,15 +12,23 @@ struct UserProfileSummaryView: View {
                 Text("Chronotype: \(profile.chronotype.rawValue.capitalized)")
             }
             Section("Caffeine") {
-                Text("Cups per day: \(profile.caffeineIntakePerDay)")
-                Text("Last at: \(time(profile.caffeineTimeLastUsed))")
+                Text("Intake: \(profile.caffeineMgPerDay) mg/day")
+                Text("Morning: \(profile.caffeineMorning ? "Yes" : "No")")
+                Text("Afternoon: \(profile.caffeineAfternoon ? "Yes" : "No")")
+                Text("Evening: \(profile.caffeineEvening ? "Yes" : "No")")
+                Text("e.g. 1 cup coffee ≈ 95 mg, 1 iced tea ≈ 40 mg")
+                    .font(.footnote).foregroundColor(.secondary)
             }
             Section("Activity") {
                 Text("Exercise per week: \(profile.exerciseFrequency)")
-                Text("Stress: \(profile.stressLevel)/5")
             }
             if let notes = profile.notes, !notes.isEmpty {
                 Section("Notes") { Text(notes) }
+            }
+            Section {
+                NavigationLink("Data") {
+                    DataView()
+                }
             }
             Section("Debug") { Text(profile.debugSummary()) }
         }


### PR DESCRIPTION
## Summary
- reintroduce DataView toggle for simulated data
- link Data page from the User profile
- track caffeine in mg with morning/afternoon/evening switches
- drop stress level field
- pipe user notes & health data context into OpenAI prompts

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685c7dea2370832fb5f2bff5ce03f415