### PR TITLE
Improve user tab UI

### DIFF
--- a/EnFlow/Views/MeetSolView.swift
+++ b/EnFlow/Views/MeetSolView.swift
@@ -13,7 +13,8 @@ struct MeetSolView: View {
                 personalizeSection
                 footerSection
             }
-            .padding()
+            .padding(.horizontal)
+            .padding(.vertical, 32)
         }
         .navigationTitle("Meet Sol")
         .navigationBarTitleDisplayMode(.large)
@@ -111,7 +112,11 @@ struct MeetSolView: View {
     }
 
     private var sampleWave: [Double] {
-        [0.3,0.5,0.7,0.9,0.8,0.6,0.4,0.3,0.2,0.3,0.5,0.8,0.9,0.7,0.5,0.4,0.3,0.5,0.7,0.9,0.8,0.6,0.4,0.2]
+        let count = 24
+        return (0..<count).map { i in
+            let x = Double(i) / Double(count - 1) * .pi * 2
+            return 0.5 + 0.4 * sin(x)
+        }
     }
 
     // MARK: Calendar

--- a/EnFlow/Views/UserProfileSummaryView.swift
+++ b/EnFlow/Views/UserProfileSummaryView.swift
@@ -26,14 +26,21 @@ struct UserProfileSummaryView: View {
                 Section("Notes") { Text(notes) }
             }
             Section {
-                NavigationLink("Data") { DataView() }
+                NavigationLink {
+                    DataView()
+                } label: {
+                    Label("Data", systemImage: "chart.bar")
+                }
                 NavigationLink {
                     MeetSolView()
                 } label: {
                     Label("Meet Sol", systemImage: "sun.max.fill")
                 }
             }
-            Section("Debug") { Text(profile.debugSummary()) }
+            Section("Debug") {
+                Text(profile.debugSummary())
+                    .foregroundColor(.secondary)
+            }
         }
         .navigationTitle("User Profile")
         .toolbar {
@@ -41,6 +48,9 @@ struct UserProfileSummaryView: View {
                 Button("Edit Profile") { showEdit = true }
             }
         }
+        .listStyle(.insetGrouped)
+        .scrollContentBackground(.hidden)
+        .enflowBackground()
         .sheet(isPresented: $showEdit, onDismiss: { profile = UserProfileStore.load() }) {
             UserProfileQuizView()
         }


### PR DESCRIPTION
## Summary
- smooth out sample wave
- apply safe vertical padding in Meet Sol view
- refresh Data link look in user profile summary
- grey out debug section
- give user profile the gradient background

## Testing
- `swift test -l` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685c918be84c832f8dc2bfbb50a8d5dc