### PR TITLE
Dashboard and forecasting enhancements

### DIFF
--- a/EnFlow/Models/EnergyForecastModel.swift
+++ b/EnFlow/Models/EnergyForecastModel.swift
@@ -91,6 +91,8 @@ final class EnergyForecastModel: ObservableObject {
       }
     }
 
+    wave = smooth(wave)
+
     let score = wave.reduce(0, +) / Double(wave.count) * 100.0
 
     let required: Set<MetricType> = [.stepCount, .restingHR, .activeEnergyBurned]
@@ -164,6 +166,16 @@ final class EnergyForecastModel: ObservableObject {
   private func activityScore(steps: Int, mean: Int = 8000, sd: Int = 3000) -> Double {
     let z = Double(steps - mean) / Double(sd)
     return exp(-0.5 * z * z)  // Gaussian bell, 0–1
+  }
+
+  /// Simple 3-point moving average to smooth abrupt dips
+  private func smooth(_ values: [Double]) -> [Double] {
+    guard values.count > 2 else { return values }
+    var out = values
+    for i in 1..<(values.count - 1) {
+      out[i] = (values[i-1] + values[i] + values[i+1]) / 3
+    }
+    return out
   }
 
   /// Consensus circadian energy curve (dips ≈ 2 am & 3 pm; peaks ≈ 10 am & 6 pm)

--- a/EnFlow/Views/Components/EnergyRingView.swift
+++ b/EnFlow/Views/Components/EnergyRingView.swift
@@ -137,11 +137,7 @@ struct EnergyRingView: View {
             }
         }
         .sheet(isPresented: $showExplanation) {
-            ExplainSheetView(
-                header: score != nil ? "Your Energy Score: \(Int(score!))" : "Energy Score Unavailable",
-                bullets: explainers,
-                timestamp: summaryDate
-            )
+            NavigationView { MeetSolView() }
         }
     }
 }

--- a/EnFlow/Views/Components/ThreePartForecastView.swift
+++ b/EnFlow/Views/Components/ThreePartForecastView.swift
@@ -7,7 +7,8 @@
 import SwiftUI
 
 struct ThreePartForecastView: View {
-  let parts: EnergyForecastModel.EnergyParts
+  /// `nil` values indicate missing Health data for that period.
+  let parts: EnergyForecastModel.EnergyParts?
   var dashed: Bool = false
   var desaturate: Bool = false
 
@@ -17,16 +18,16 @@ struct ThreePartForecastView: View {
 
   var body: some View {
     HStack(spacing: spacing) {
-      ring(title: "Morning", value: parts.morning, startHour: 5)
-      ring(title: "Afternoon", value: parts.afternoon, startHour: 12)
-      ring(title: "Evening", value: parts.evening, startHour: 17)
+      ring(title: "Morning", value: parts?.morning, startHour: 5)
+      ring(title: "Afternoon", value: parts?.afternoon, startHour: 12)
+      ring(title: "Evening", value: parts?.evening, startHour: 17)
     }
     .frame(maxWidth: .infinity)
     .saturation(desaturate ? 0.6 : 1.0)
   }
 
   @ViewBuilder
-  private func ring(title: String, value: Double, startHour: Int) -> some View {
+  private func ring(title: String, value: Double?, startHour: Int) -> some View {
     let currentHour = Calendar.current.component(.hour, from: Date())
     let isAvailable = currentHour >= startHour
 
@@ -41,11 +42,11 @@ struct ThreePartForecastView: View {
           )
           .frame(width: ringSize, height: ringSize)
 
-        if isAvailable {
+        if isAvailable, let val = value {
           Circle()
-            .trim(from: 0, to: CGFloat(value / 100))
+            .trim(from: 0, to: CGFloat(val / 100))
             .stroke(
-              ColorPalette.gradient(for: value),
+              ColorPalette.gradient(for: val),
               style: StrokeStyle(
                 lineWidth: lineWidth,
                 lineCap: .round,
@@ -58,7 +59,7 @@ struct ThreePartForecastView: View {
             Text(title)
               .font(.caption)
               .foregroundColor(.white)
-            Text("\(Int(value))")
+            Text("\(Int(val))")
               .font(.title3.bold())
               .foregroundColor(.white)
           }
@@ -69,11 +70,11 @@ struct ThreePartForecastView: View {
         }
       }
 
-      if isAvailable {
-        Text(status(for: value))
+      if isAvailable, let val = value {
+        Text(status(for: val))
           .font(.caption2)
           .fontWeight(.medium)
-          .foregroundColor(ColorPalette.color(for: value))
+          .foregroundColor(ColorPalette.color(for: val))
       }
     }
     .frame(width: ringSize, height: ringSize + 24)

--- a/EnFlow/Views/DashboardView.swift
+++ b/EnFlow/Views/DashboardView.swift
@@ -23,14 +23,8 @@ struct DashboardView: View {
   @State private var todaySummary: DayEnergySummary?
   @State private var tomorrowSummary: DayEnergySummary?
 
-  @State private var todayParts = EnergyForecastModel.EnergyParts(
-    morning: 0,
-    afternoon: 0,
-    evening: 0)
-  @State private var tomorrowParts = EnergyForecastModel.EnergyParts(
-    morning: 0,
-    afternoon: 0,
-    evening: 0)
+  @State private var todayParts: EnergyParts? = nil
+  @State private var tomorrowParts: EnergyParts? = nil
   @State private var todayCtx: SuggestedPriorityContext?
   @State private var tomorrowCtx: SuggestedPriorityContext?
 
@@ -56,7 +50,6 @@ struct DashboardView: View {
         .tag(1)
     }
     .tabViewStyle(.page(indexDisplayMode: .never))
-    .animation(.easeInOut, value: selection)
 
     // ───────── Segmented pill ─────────
     .overlay(alignment: .topTrailing) {
@@ -146,6 +139,8 @@ struct DashboardView: View {
       .padding(.top, headerPadding)
       .padding(.horizontal)
     }
+    .scrollIndicators(.hidden)
+    .scrollIndicators(.hidden)
   }
 
   // MARK: TOMORROW PAGE -------------------------------------------------------
@@ -308,8 +303,8 @@ struct DashboardView: View {
     await MainActor.run {
       todaySummary = tSummary
       tomorrowSummary = tmSummary
-      todayParts = tParts
-      tomorrowParts = tmParts
+      todayParts = noToday ? nil : tParts
+      tomorrowParts = noTomorrow ? nil : tmParts
       todayCtx = tCtx
       tomorrowCtx = tmCtx
       stepsToday = steps


### PR DESCRIPTION
## Summary
- smooth hourly energy predictions to avoid abrupt dips
- mark missing data in three-part rings with dashes
- hide dashboard scroll indicators and simplify swipe animation
- show Meet Sol interface from energy ring info
- handle missing health data in Day view mini rings

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685c94583260832fa0db8ce09a7dee98