### PR TITLE
Adjust baseline energy scoring around 70

### DIFF
--- a/EnFlow/Models/EnergyForecastModel.swift
+++ b/EnFlow/Models/EnergyForecastModel.swift
@@ -41,7 +41,8 @@ final class EnergyForecastModel: ObservableObject {
       summaryEngine.summarize(
         day: day,
         healthEvents: healthByDay[day] ?? [],
-        calendarEvents: eventsByDay[day] ?? [])
+        calendarEvents: eventsByDay[day] ?? [],
+        profile: nil)
     }
   }
 

--- a/EnFlow/Models/UnifiedEnergyModel.swift
+++ b/EnFlow/Models/UnifiedEnergyModel.swift
@@ -21,7 +21,8 @@ final class UnifiedEnergyModel {
 
         let summary = summaryEngine.summarize(day: date,
                                               healthEvents: healthEvents,
-                                              calendarEvents: calendarEvents)
+                                              calendarEvents: calendarEvents,
+                                              profile: profile)
 
         guard let forecast = forecastModel.forecast(for: date,
                                                     health: healthEvents,

--- a/EnFlow/Views/Components/DayView.swift
+++ b/EnFlow/Views/Components/DayView.swift
@@ -336,11 +336,13 @@ struct DayView: View {
   private func load() async {
     let healthList = await HealthDataPipeline.shared.fetchDailyHealthEvents(daysBack: 7)
     let dayEvents = await CalendarDataPipeline.shared.fetchEvents(for: currentDate)
+    let profile = UserProfileStore.load()
 
     let summary = EnergySummaryEngine.shared.summarize(
       day: currentDate,
       healthEvents: healthList,
-      calendarEvents: dayEvents)
+      calendarEvents: dayEvents,
+      profile: profile)
     forecast = summary.hourlyWaveform
     let today = calendar.startOfDay(for: Date())
     if currentDate > today || summary.coverageRatio < 0.3 {


### PR DESCRIPTION
## Summary
- update `EnergySummaryEngine` to bias average scores toward 70
- allow user profile to influence final energy score
- propagate new `profile` parameter in callers

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c9a0d2050832f85ec478ecfe1b5fb