### PR TITLE
Fix scrolling issue with extra padding

### DIFF
--- a/EnFlow/Views/DataView.swift
+++ b/EnFlow/Views/DataView.swift
@@ -83,6 +83,7 @@ struct DataView: View {
                     }
                 }
             }
+            .padding(.vertical, 200)
             if isLoading {
                 ProgressView().progressViewStyle(.circular)
             }

--- a/EnFlow/Views/MeetSolView.swift
+++ b/EnFlow/Views/MeetSolView.swift
@@ -14,7 +14,7 @@ struct MeetSolView: View {
                 footerSection
             }
             .padding(.horizontal)
-            .padding(.vertical, 100)
+            .padding(.vertical, 200)
         }
         .navigationTitle("Meet Sol")
         .navigationBarTitleDisplayMode(.large)

--- a/EnFlow/Views/UserProfileSummaryView.swift
+++ b/EnFlow/Views/UserProfileSummaryView.swift
@@ -42,6 +42,7 @@ struct UserProfileSummaryView: View {
                     .foregroundColor(.secondary)
             }
         }
+        .padding(.vertical, 200)
         .navigationTitle("User Profile")
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {


### PR DESCRIPTION
## Summary
- add generous vertical padding to `DataView` list
- make `MeetSolView` container use large vertical padding
- pad `UserProfileSummaryView` list to help scrolling

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c9e5ad1b4832fb0bd703805f6bf6b