### PR TITLE
Reduce energy ring scale

### DIFF
--- a/EnFlow/Views/Components/EnergyRingView.swift
+++ b/EnFlow/Views/Components/EnergyRingView.swift
@@ -22,6 +22,9 @@ struct EnergyRingView: View {
     @State private var pulseScale = 1.0
     @State private var showExplanation = false
 
+    // Base scale applied so the composite ring appears slightly smaller
+    private let baseScale: CGFloat = 0.9
+
     // ───────── Derived ──────────────────────────────────────────────
     private var status: String {
         guard let score else { return "N/A" }
@@ -127,7 +130,7 @@ struct EnergyRingView: View {
             }
         }
         .frame(width: 180, height: 180)
-        .scaleEffect(pulseScale)
+        .scaleEffect(baseScale * pulseScale)
         .shadow(color: .black.opacity(0.35), radius: 8, x: 0, y: 4)
         .saturation(desaturate ? 0.55 : 1.0)
         .onReceive(engine.$refreshVersion.dropFirst()) { _ in


### PR DESCRIPTION
## Summary
- adjust EnergyRingView so the composite ring renders slightly smaller across the app

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ca7ae0b6c832fbc1353a48f135d04