### PR TITLE
Fix scroll issues with safe area aware background

### DIFF
--- a/EnFlow/Views/DashboardView.swift
+++ b/EnFlow/Views/DashboardView.swift
@@ -354,7 +354,7 @@ struct DashboardView: View {
 extension View {
   /// Navy-to-charcoal gradient, ignoring safe-area.
   func enflowBackground() -> some View {
-    self.background(
+    background {
       LinearGradient(
         gradient: Gradient(colors: [
           Color(red: 0.05, green: 0.08, blue: 0.20),  // deep navy
@@ -363,7 +363,7 @@ extension View {
         startPoint: .topLeading,
         endPoint: .bottomTrailing
       )
-    )
-    .ignoresSafeArea()
+      .ignoresSafeArea()
+    }
   }
 }

--- a/EnFlow/Views/DataView.swift
+++ b/EnFlow/Views/DataView.swift
@@ -83,10 +83,9 @@ struct DataView: View {
                     }
                 }
             }
-            .padding(.vertical, 200)
-            if isLoading {
-                ProgressView().progressViewStyle(.circular)
-            }
+        if isLoading {
+            ProgressView().progressViewStyle(.circular)
+        }
         }
         .listStyle(.insetGrouped)
         .scrollContentBackground(.hidden)

--- a/EnFlow/Views/UserProfileSummaryView.swift
+++ b/EnFlow/Views/UserProfileSummaryView.swift
@@ -42,12 +42,10 @@ struct UserProfileSummaryView: View {
                     .foregroundColor(.secondary)
             }
         }
-        .padding(.vertical, 200)
         .navigationTitle("User Profile")
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button("Edit Profile") { showEdit = true }
-                padding()
             }
         }
         .listStyle(.insetGrouped)


### PR DESCRIPTION
## Summary
- keep gradient background but make it ignore safe area only for the gradient layer
- drop manual bottom insets from `DataView` and `UserProfileSummaryView`
- remove stray padding from profile toolbar button

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cabb2d5c0832fa6710a2d752e0440