### PR TITLE
Enhance weekly GPT summary formatting

### DIFF
--- a/EnFlow/Utilities/WeeklySummaryFormatter.swift
+++ b/EnFlow/Utilities/WeeklySummaryFormatter.swift
@@ -16,9 +16,15 @@ enum WeeklySummaryFormatter {
             .replacingOccurrences(of: "\u{201D}", with: "\"")
             .trimmingCharacters(in: .whitespacesAndNewlines)
 
+        // Extract JSON substring if extraneous text surrounds it
+        if let start = cleaned.firstIndex(of: "{"),
+           let end = cleaned.lastIndex(of: "}") {
+            cleaned = String(cleaned[start...end])
+        }
+
         guard let data = cleaned.data(using: .utf8),
               let summary = try? JSONDecoder().decode(Summary.self, from: data) else {
-            return cleaned
+            return JSONFormatter.pretty(from: cleaned)
         }
 
         var lines: [String] = []

--- a/EnFlow/Views/TrendsView.swift
+++ b/EnFlow/Views/TrendsView.swift
@@ -197,15 +197,15 @@ struct TrendsView: View {
         await loadGPTSummary()
     }
 
-    /// Reload only the GPT JSON summary with strict formatting instructions.
+    /// Reload only the GPT JSON summary with simplified formatting instructions.
     private func loadGPTSummary() async {
         let prompt = """
-STRICTLY output EXACTLY valid JSON with NO markdown, no code fences, no extra fields. The JSON must have two keys:
-
-"sections": array of objects with keys "title" and "content" (both strings),
-"events": array of objects with keys "title" and "date" (ISO 8601 YYYY-MM-DD).
-
-Analyze correlations between the user's calendar events and their energy data. Wrap any referenced event title in <highlight>…</highlight> tags. Output only the JSON object.
+Respond only with JSON.
+{
+  "sections": [{"title":"","content":""}],
+  "events": [{"title":"","date":"YYYY-MM-DD"}]
+}
+Highlight any mentioned event titles using <highlight> tags. No markdown or extra commentary.
 """
         do {
             let raw = try await OpenAIManager.shared.generateInsight(


### PR DESCRIPTION
## Summary
- simplify the prompt for the weekly JSON summary
- make `WeeklySummaryFormatter` resilient to extra text and always pretty print JSON

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685cadc59128832fb93b6cc98012fbf6