### PR TITLE
Trim view padding and fix week header

### DIFF
--- a/EnFlow/Views/Components/WeekCalendarView.swift
+++ b/EnFlow/Views/Components/WeekCalendarView.swift
@@ -20,28 +20,24 @@ struct WeekCalendarView: View {
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
-                // ─── Two-line header: “Week” + “Week of …” ─────────────
-                VStack(spacing: 6) {
-                    HStack {
-                        Button { shiftWeek(by: -1) } label: {
-                            Image(systemName: "chevron.left")
-                                .padding(8)
-                        }
-                        Spacer()
-                        Button { shiftWeek(by: 1) } label: {
-                            Image(systemName: "chevron.right")
-                                .padding(8)
-                        }
+                // ─── Header with inline week title ─────────────
+                HStack {
+                    Button { shiftWeek(by: -1) } label: {
+                        Image(systemName: "chevron.left")
+                            .padding(8)
                     }
-                    .padding(.horizontal)
-
+                    Spacer()
                     Text(weekTitle)
                         .font(.subheadline)
                         .foregroundColor(.white.opacity(0.85))
-                        .padding(.horizontal)
+                    Spacer()
+                    Button { shiftWeek(by: 1) } label: {
+                        Image(systemName: "chevron.right")
+                            .padding(8)
+                    }
                 }
-                .padding(.top, 1)
-                .padding(.bottom, 80)
+                .padding(.horizontal)
+                .padding(.vertical, 8)
 
                 // ─── Week grid, vertical-only scroll ────────────────────
                 ScrollView(.vertical, showsIndicators: true) {
@@ -160,8 +156,8 @@ struct WeekCalendarView: View {
                     }
                 }
             }
-            // make the persistent nav-bar show “Week of …” instead of static “Week”
-            .navigationTitle(weekTitle)
+            // Keep simple title in the nav bar
+            .navigationTitle("Week")
             .navigationBarTitleDisplayMode(.inline)
 
             // add left/right swipe anywhere to change weeks

--- a/EnFlow/Views/OnboardingAndSettingsView.swift
+++ b/EnFlow/Views/OnboardingAndSettingsView.swift
@@ -63,6 +63,7 @@ struct OnboardingAndSettingsView: View {
             }
             .scrollContentBackground(.hidden)
             .navigationTitle("Settings")
+            .navigationBarTitleDisplayMode(.inline)
         }
         .enflowBackground()
         .onAppear(perform: refreshAuthStatus)

--- a/EnFlow/Views/TrendsView.swift
+++ b/EnFlow/Views/TrendsView.swift
@@ -49,7 +49,6 @@ struct TrendsView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
-                Spacer().frame(height: 80)
 
                 // Sub-navigation picker
                 Picker("", selection: $period) {


### PR DESCRIPTION
## Summary
- remove top spacer from `TrendsView`
- keep Settings title small with inline mode
- streamline week view header so the title sits between navigation chevrons and shrink padding
- show a simple `Week` title in the navigation bar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685cbf430da4832fa572e2655d90b815