### PR TITLE
Improve weekly summary parsing

### DIFF
--- a/EnFlowTests/EnFlowTests.swift
+++ b/EnFlowTests/EnFlowTests.swift
@@ -33,4 +33,18 @@ struct EnFlowTests {
         #expect(text.contains("E"))
     }
 
+    @Test func weeklySummaryFormatterHandlesWrappedJSON() throws {
+        let raw = "Here you go: ```json\n{" +
+            "\"sections\":[{\"title\":\"A\",\"content\":\"B\"}]," +
+            "\"events\":[]}\n``` Enjoy!"
+        let text = WeeklySummaryFormatter.format(from: raw)
+        #expect(text.contains("\u2022 A: B"))
+    }
+
+    @Test func weeklySummaryFormatterFallsBackGracefully() throws {
+        let raw = "not really json"
+        let text = WeeklySummaryFormatter.format(from: raw)
+        #expect(text.contains("not really json"))
+    }
+
 }


### PR DESCRIPTION
## Summary
- make the weekly summary formatter parse more variants of GPT output
- add tests for wrapped JSON and invalid input

## Testing
- `swift test -l` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685cc8775558832f885c11facfe34440