### PR TITLE
Fix overlapping back button

### DIFF
--- a/EnFlow/Views/DataView.swift
+++ b/EnFlow/Views/DataView.swift
@@ -18,6 +18,7 @@ struct DataView: View {
     @State private var range: DataRange = .week
     @State private var isLoading = false
     @AppStorage("useSimulatedHealthData") private var useSimulatedHealthData = false
+    @Environment(\.dismiss) private var dismiss
 
     var body: some View {
         ZStack {
@@ -90,7 +91,17 @@ struct DataView: View {
         .listStyle(.insetGrouped)
         .scrollContentBackground(.hidden)
         .navigationTitle("Data")
+        .navigationBarBackButtonHidden(true)
         .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button(action: { dismiss() }) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "chevron.backward")
+                        Text("Back")
+                    }
+                }
+                .padding(.leading, 32)
+            }
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button { showDateSheet = true } label: {
                     Image(systemName: "calendar")

--- a/EnFlow/Views/MeetSolView.swift
+++ b/EnFlow/Views/MeetSolView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct MeetSolView: View {
     @State private var showMetrics = false
     @State private var pulse = false
+    @Environment(\.dismiss) private var dismiss
     var body: some View {
         ScrollView {
             VStack(spacing: 28) {
@@ -18,6 +19,18 @@ struct MeetSolView: View {
         }
         .navigationTitle("Meet Sol")
         .navigationBarTitleDisplayMode(.large)
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button(action: { dismiss() }) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "chevron.backward")
+                        Text("Back")
+                    }
+                }
+                .padding(.leading, 32)
+            }
+        }
         .sheet(isPresented: $showMetrics) { MetricDetailsView() }
         .enflowBackground()
     }


### PR DESCRIPTION
## Summary
- shift gear-overlapping back buttons in DataView and MeetSolView

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_685cc8ad408c832fbd01b8bff210d2f6