### PR TITLE
Fix wrapping for energy ring labels

### DIFF
--- a/EnFlow/Views/Components/DayView.swift
+++ b/EnFlow/Views/Components/DayView.swift
@@ -281,9 +281,10 @@ struct DayView: View {
       }
       Text(title)
         .font(.caption2)
+        .lineLimit(1)
         .foregroundColor(.white.opacity(0.7))
     }
-    .frame(width: 32)
+    .frame(width: 60)
   }
 
   // MARK: ─ Day-swipe gesture ─────────────────────────────────


### PR DESCRIPTION
## Summary
- expand mini ring label width in `DayView`
- prevent two-line wrapping on the ring labels

## Testing
- `swift test -l` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cc9afad14832f942b8a055a556f01