### PR TITLE
Show per-day energy curve in calendar view

### DIFF
--- a/EnFlow/Views/Components/DailyEnergyForecastView.swift
+++ b/EnFlow/Views/Components/DailyEnergyForecastView.swift
@@ -1,10 +1,17 @@
 import SwiftUI
 
 struct DailyEnergyForecastView: View {
-    /// Energy values from 7 AM to 7 PM inclusive (13 values, 0-1)
+    /// Energy values for consecutive hours starting at `startHour`.
     let values: [Double]
-    private let startHour = 7
+    /// First hour represented in `values`. Defaults to 7AM for backward
+    /// compatibility with the dashboard.
+    let startHour: Int
     private let calendar = Calendar.current
+
+    init(values: [Double], startHour: Int = 7) {
+        self.values = values
+        self.startHour = startHour
+    }
 
     var body: some View {
         GeometryReader { proxy in


### PR DESCRIPTION
## Summary
- support custom start hour for `DailyEnergyForecastView`
- display day-specific energy graph in day view using that style
- fetch health data range based on selected day

## Testing
- `swift test -v` *(fails: `Could not find Package.swift`)*
- `xcodebuild -scheme EnFlow -destination 'platform=iOS Simulator,name=iPhone 15 Pro' test` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685cd878907c832fac8caaf85704bc77