### PR TITLE
Fix day view heatmap behaviour

### DIFF
--- a/EnFlow/Views/Components/DotPatternOverlay.swift
+++ b/EnFlow/Views/Components/DotPatternOverlay.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+/// Simple dotted overlay used to indicate forecasted energy segments.
+struct DotPatternOverlay: View {
+    var color: Color = .white
+    var body: some View {
+        GeometryReader { proxy in
+            Canvas { ctx, size in
+                let spacing: CGFloat = 4
+                let radius: CGFloat = 1.5
+                var y: CGFloat = radius
+                while y < size.height {
+                    var x: CGFloat = radius
+                    while x < size.width {
+                        let rect = CGRect(x: x - radius, y: y - radius, width: radius * 2, height: radius * 2)
+                        ctx.fill(Path(ellipseIn: rect), with: .color(color.opacity(0.3)))
+                        x += spacing
+                    }
+                    y += spacing
+                }
+            }
+        }
+    }
+}
+
+#if DEBUG
+struct DotPatternOverlay_Previews: PreviewProvider {
+    static var previews: some View {
+        DotPatternOverlay(color: .orange)
+            .frame(width: 100, height: 40)
+            .background(Color.black)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add dotted overlay for forecast cells
- show dynamic time indicator and hide heatmap without data
- use blended energy summary in DayView
- apply gradient colouring and stipple overlay

## Testing
- `swiftc EnFlow/Views/Components/DotPatternOverlay.swift -parse`
- `swiftc EnFlow/Views/Components/DayView.swift -parse` *(fails: attribute 'private' can only be used in a non-local scope)*

------
https://chatgpt.com/codex/tasks/task_e_68619369b618832f92128f4db4bd4e67