### PR TITLE
Fix trends period picker to reload graph

### DIFF
--- a/EnFlow/Views/TrendsView.swift
+++ b/EnFlow/Views/TrendsView.swift
@@ -63,6 +63,9 @@ struct TrendsView: View {
                     ForEach(TrendsPeriod.allCases) { p in Text(p.rawValue).tag(p) }
                 }
                 .pickerStyle(.segmented)
+                .onChange(of: period) { _ in
+                    Task { await loadData() }
+                }
                 .padding(.horizontal)
 
                 // Energy chart title


### PR DESCRIPTION
## Summary
- trigger data reload when period picker changes in Trends view

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68619052bc2c832fb50842347321e316