### PR TITLE
Fix DayView build error

### DIFF
--- a/EnFlow/Views/Components/DayView.swift
+++ b/EnFlow/Views/Components/DayView.swift
@@ -235,8 +235,11 @@ struct DayView: View {
         }
         .frame(maxHeight: .infinity)
       }
+
       .frame(height: rowHeight)
     }
+  }
+
   }
 
   private func eventHeight(from ev: CalendarEvent) -> CGFloat {


### PR DESCRIPTION
## Summary
- close the `timelineRow` method properly
- keep `labeledMiniRing` usable

## Testing
- `swiftc -parse EnFlow/Views/Components/DayView.swift`

------
https://chatgpt.com/codex/tasks/task_e_6861a3caa3a4832fa115563edd475bc8