### PR TITLE
Fix permission toggles

### DIFF
--- a/EnFlow/Views/OnboardingAndSettingsView.swift
+++ b/EnFlow/Views/OnboardingAndSettingsView.swift
@@ -145,7 +145,13 @@ struct OnboardingAndSettingsView: View {
     private func calendarToggleChanged(_ newValue: Bool) {
         if newValue {
             CalendarDataPipeline.shared.requestAccess { calendarGranted = $0 }
-        } else { showSettingsAlert = true }
+        } else {
+            // Permissions can only be revoked in the iOS Settings app. If the
+            // user cancels the alert, keep the toggle enabled so the state
+            // reflects the actual authorization status.
+            showSettingsAlert = true
+            calendarGranted = true
+        }
     }
 
     private func healthToggleChanged(_ newValue: Bool) {
@@ -154,7 +160,11 @@ struct OnboardingAndSettingsView: View {
                 healthGranted = $0
                 updateHealthGranted()
             }
-        } else { showSettingsAlert = true }
+        } else {
+            // Mirror the same revoke-flow behavior for Health permissions.
+            showSettingsAlert = true
+            healthGranted = true
+        }
     }
 
     private func systemSettingsButtons() -> some View {


### PR DESCRIPTION
## Summary
- keep Calendar and Health toggles enabled unless permissions are revoked in iOS settings

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a5bf56e4832f8775363f0edff308