### PR TITLE
Add current hour indicator to forecast

### DIFF
--- a/EnFlow/Views/Components/DayView.swift
+++ b/EnFlow/Views/Components/DayView.swift
@@ -114,7 +114,11 @@ struct DayView: View {
         ThreePartForecastView(parts: parts)
         Text("24-Hour Energy Graph")
           .font(.title2.weight(.medium))
-        DailyEnergyForecastView(values: forecast, startHour: 0)
+        DailyEnergyForecastView(
+          values: forecast,
+          startHour: 0,
+          highlightHour: isToday ? calendar.component(.hour, from: now) : nil
+        )
           .frame(height: 220)
       }
       .padding()


### PR DESCRIPTION
## Summary
- allow `DailyEnergyForecastView` to highlight a specific hour
- draw a pulsing dot at the highlight hour
- show the pulsing dot when viewing today's 24‑hour graph

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6861addbc1fc832f976d3d00cb850686