### PR TITLE
Improve energy forecast stability

### DIFF
--- a/EnFlow/Models/DayEnergyForecast.swift
+++ b/EnFlow/Models/DayEnergyForecast.swift
@@ -13,4 +13,6 @@ struct DayEnergyForecast: Codable {
     let confidenceScore: Double   // 0…1
     let missingMetrics: [MetricType]
     let sourceType: SourceType
+    /// Optional debug description when forecast confidence is low.
+    let debugInfo: String?
 }


### PR DESCRIPTION
## Summary
- add optional debug info to `DayEnergyForecast`
- apply event deltas over a 3‑hour window
- smooth energy values with a 5‑point kernel
- clamp values and adjust amplitude based on confidence
- force sleep floor when health data is missing

## Testing
- `swift --version`
- `swiftc -typecheck EnFlow/Models/EnergyForecastModel.swift` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_6861afd85558832fa81b1bc8e4fd00bb