### PR TITLE
Switch monthly axes to weeks

### DIFF
--- a/EnFlow/Views/TrendsView.swift
+++ b/EnFlow/Views/TrendsView.swift
@@ -327,7 +327,7 @@ struct TrendsView: View {
     @AxisContentBuilder
     private var xAxisMarks: some AxisContent {
         switch period {
-        case .weekly:
+       case .weekly:
             AxisMarks(values: .stride(by: .day)) { value in
                 if let date = value.as(Date.self) {
                     AxisTick()
@@ -335,8 +335,8 @@ struct TrendsView: View {
                 }
             }
         case .monthly, .sixWeeks:
-            AxisMarks(values: .stride(by: .day)) { value in
-                if value.as(Date.self) != nil {
+            AxisMarks(values: .stride(by: .weekOfYear)) { value in
+                if let date = value.as(Date.self) {
                     AxisTick()
                     AxisValueLabel(format: .dateTime.month(.abbreviated).day())
                 }


### PR DESCRIPTION
## Summary
- change the monthly and six week energy chart axes to use week intervals

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861b554ae70832fa367f34aa0a90d31