### PR TITLE
Fix glitchy dashboard swiping

### DIFF
--- a/EnFlow/Views/DashboardView.swift
+++ b/EnFlow/Views/DashboardView.swift
@@ -37,17 +37,6 @@ struct DashboardView: View {
   @State private var missingTomorrowData = false
   @State private var tomorrowConfidence: Double = 0
 
-  /// Drag gesture to move between Today and Tomorrow pages.
-  private var pageSwipe: some Gesture {
-    DragGesture(minimumDistance: 20)
-      .onEnded { value in
-        if value.translation.width > 50 {
-          changePage(by: -1)
-        } else if value.translation.width < -50 {
-          changePage(by: 1)
-        }
-      }
-  }
 
   private typealias EnergyParts = EnergyForecastModel.EnergyParts
 
@@ -66,8 +55,7 @@ struct DashboardView: View {
 
       if isLoading { ProgressView().progressViewStyle(.circular) }
     }
-    .contentShape(Rectangle())
-    .gesture(pageSwipe)
+
 
     // ───────── Segmented pill ─────────
     .overlay(alignment: .topTrailing) {
@@ -334,13 +322,6 @@ struct DashboardView: View {
     }
   }
 
-  /// Move the tab selection left or right when swiping.
-  private func changePage(by delta: Int) {
-    let newIndex = selection + delta
-    if (0...1).contains(newIndex) {
-      withAnimation { selection = newIndex }
-    }
-  }
 
   /// Returns ≥15-minute gaps in the day’s schedule.
   private func freeBlocks(from events: [CalendarEvent], for day: Date) -> [DateInterval] {


### PR DESCRIPTION
## Summary
- remove custom `DragGesture` handling in `DashboardView`
- delete unused `changePage` helper

`TabView` already supports page-style swiping; the additional drag gesture was causing the page to overshoot and snap back when swiping between Today and Tomorrow.

## Testing
- `xcodebuild -list -project EnFlow.xcodeproj` *(fails: xcodebuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861b8a1c714832fb4a1d3642d285391