### PR TITLE
Add coming soon overlay

### DIFF
--- a/EnFlow/Views/OnboardingAndSettingsView.swift
+++ b/EnFlow/Views/OnboardingAndSettingsView.swift
@@ -116,6 +116,14 @@ struct OnboardingAndSettingsView: View {
     private var preferencesSection: some View {
         Section(header: Text("App Preferences")) {
             Toggle("Enable Notifications", isOn: .constant(false))
+                .disabled(true)
+                .overlay(
+                    ZStack {
+                        Color.gray.opacity(0.4)
+                        Text("Coming Soon")
+                            .foregroundColor(.blue)
+                    }
+                )
             Picker("GPT Tone", selection: $gptTone) {
                 Text("Wellness").tag("wellness")
                 Text("Scientific").tag("scientific")


### PR DESCRIPTION
## Summary
- disable notification toggle and overlay with grey box
- display "Coming Soon" in blue text over the toggle

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6861c2c16034832fb803745d8e5615fd