### PR TITLE
Adjust 24‑hour graph tick interval

### DIFF
--- a/EnFlow/Views/Components/DailyEnergyForecastView.swift
+++ b/EnFlow/Views/Components/DailyEnergyForecastView.swift
@@ -64,7 +64,7 @@ struct DailyEnergyForecastView: View {
             }
 
             // hour labels
-            ForEach(0..<count, id: \.self) { idx in
+            ForEach(Array(stride(from: 0, to: count, by: 2)), id: \.self) { idx in
                 let x = width * CGFloat(idx) / CGFloat(max(count - 1, 1))
                 Text(hourLabel(startHour + idx))
                     .font(.system(size: 8))


### PR DESCRIPTION
## Summary
- display fewer tick labels in `DailyEnergyForecastView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6861c33fbe4c832f902f090c36740834