### PR TITLE
Add 'now' dot to dashboard energy graph

### DIFF
--- a/EnFlow/Views/DashboardView.swift
+++ b/EnFlow/Views/DashboardView.swift
@@ -125,7 +125,10 @@ struct DashboardView: View {
           VStack(alignment: .leading, spacing: 8) {
             Text("Daily Energy Forecast")
                   .font(.headline)
-            DailyEnergyForecastView(values: slice)
+            DailyEnergyForecastView(
+              values: slice,
+              highlightHour: Calendar.current.component(.hour, from: Date())
+            )
           }
         }
 


### PR DESCRIPTION
## Summary
- show pulsing dot for current hour in the dashboard's Daily Energy Forecast

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6861c399679c832f914fe120196754ff