### PR TITLE
Add info popups for energy ring and priorities

### DIFF
--- a/EnFlow/Views/Components/EnergyRingInfoView.swift
+++ b/EnFlow/Views/Components/EnergyRingInfoView.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+struct EnergyRingInfoView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var showMore = false
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 24) {
+                    Text("The ring represents your current day’s composite energy score, a weighted blend of mental and physical readiness.")
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    ringStates
+                    Text("Sol calculates this score from:")
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    metricBullets
+                    Button("Learn how Sol calculates energy") { showMore = true }
+                        .buttonStyle(.borderedProminent)
+                }
+                .padding()
+                .background(.ultraThinMaterial)
+                .cornerRadius(20)
+                .padding()
+            }
+            .navigationTitle("Understanding Your Energy Rings")
+            .toolbar { ToolbarItem(placement: .navigationBarTrailing) { Button("Done") { dismiss() } } }
+            .sheet(isPresented: $showMore) { NavigationStack { MeetSolView() } }
+        }
+    }
+
+    private var ringStates: some View {
+        VStack(spacing: 16) {
+            ringRow(score: 25, title: "Low (0–40)", description: "Ring appears red/orange, sparse fill.")
+            ringRow(score: 55, title: "Moderate (40–65)", description: "Yellow, steady glow.")
+            ringRow(score: 78, title: "High (65–90)", description: "Vibrant green with pulse.")
+            ringRow(score: 95, title: "Supercharged (90–100)", description: "Blue-tinted white with glow.")
+        }
+    }
+
+    private func ringRow(score: Double, title: String, description: String) -> some View {
+        HStack(spacing: 16) {
+            EnergyRingView(score: score)
+                .frame(width: 60, height: 60)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title).font(.headline)
+                Text(description).font(.subheadline).foregroundColor(.secondary)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var metricBullets: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label("HRV (Heart Rate Variability) — Tracks your body’s readiness and recovery state", systemImage: "heart.fill")
+            Label("Resting Heart Rate — Reflects baseline cardiovascular stress", systemImage: "waveform.path.ecg")
+            Label("Sleep Efficiency — Measures how much of your sleep time was restorative", systemImage: "bed.double.fill")
+            Label("Sleep Latency — How quickly you fall asleep (shorter = better recovery)", systemImage: "zzz")
+            Label("Deep Sleep Duration — Critical for physical repair", systemImage: "moon.zzz.fill")
+            Label("REM Sleep Duration — Tied to focus, memory, and mood", systemImage: "eye.fill")
+            Label("Active Energy Burned — Tracks daily physical exertion", systemImage: "flame.fill")
+            Label("Step Count — Helps gauge movement load", systemImage: "figure.walk")
+            Label("Respiratory Rate — Adds physiological context", systemImage: "lungs.fill")
+            Label("Oxygen Saturation — Affects fatigue and performance potential", systemImage: "drop.fill")
+            Label("VO₂ Max — Represents cardiovascular efficiency", systemImage: "figure.mind.and.body")
+            Label("Apple Exercise Time — Movement minutes per day", systemImage: "figure.run")
+            Label("Mindfulness Minutes — Indicates mental recovery effort", systemImage: "brain.head.profile")
+        }
+        .font(.body)
+        .labelStyle(.titleAndIcon)
+    }
+}
+
+#Preview {
+    EnergyRingInfoView()
+}

--- a/EnFlow/Views/Components/EnergyRingView.swift
+++ b/EnFlow/Views/Components/EnergyRingView.swift
@@ -140,7 +140,7 @@ struct EnergyRingView: View {
             }
         }
         .sheet(isPresented: $showExplanation) {
-            NavigationView { MeetSolView() }
+            EnergyRingInfoView()
         }
     }
 }

--- a/EnFlow/Views/Components/SuggestedPrioritiesInfoView.swift
+++ b/EnFlow/Views/Components/SuggestedPrioritiesInfoView.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+struct SuggestedPrioritiesInfoView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var showProfileQuiz = false
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    ForEach(SuggestedPriorityTemplate.allCases) { t in
+                        priorityRow(t)
+                    }
+                    Divider()
+                    Text("Sol combines 3-part energy forecasts with your calendar gaps, sleep quality and HRV trends. A GPT engine ranks templates by fit. Your feedback — pin, snooze or dismiss — tunes future recommendations.")
+                        .font(.body)
+                    Button("Update your profile") { showProfileQuiz = true }
+                        .buttonStyle(.borderedProminent)
+                }
+                .padding()
+                .background(.ultraThinMaterial)
+                .cornerRadius(20)
+                .padding()
+            }
+            .navigationTitle("How Priorities Are Picked")
+            .toolbar { ToolbarItem(placement: .navigationBarTrailing) { Button("Done") { dismiss() } } }
+            .sheet(isPresented: $showProfileQuiz) { NavigationStack { UserProfileQuizView() } }
+        }
+    }
+
+    private func priorityRow(_ template: SuggestedPriorityTemplate) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: template.sfSymbol)
+                .font(.title2)
+                .frame(width: 32)
+                .foregroundColor(.accentColor)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(template.rawValue)
+                    .font(.headline)
+                Text(blurb(for: template))
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func blurb(for t: SuggestedPriorityTemplate) -> String {
+        switch t {
+        case .deepWork:           return "Best used during peak mental energy."
+        case .lightAdmin:         return "Great for lower focus periods."
+        case .activeRecovery:     return "Helps you bounce back after effort."
+        case .socialRecharge:     return "Connect with others to restore mood."
+        case .morningReflection:  return "Start your day with clarity."
+        case .windDown:           return "Ideal near bedtime or after intense sessions."
+        case .creativeSpur:       return "Suggested when mental energy is high but physical is moderate."
+        case .quickPhysicalReset: return "Short movement to perk up energy."
+        }
+    }
+}
+
+#Preview {
+    SuggestedPrioritiesInfoView()
+}

--- a/EnFlow/Views/Components/SuggestedPrioritiesView.swift
+++ b/EnFlow/Views/Components/SuggestedPrioritiesView.swift
@@ -25,13 +25,22 @@ struct SuggestedPrioritiesView: View {
   // ───────── State ──────────────────────────────────────────────
   @StateObject private var vm = SuggestedPrioritiesVM()
   @State private var selectedForExplain: PriorityResult?
+  @State private var showInfo = false
 
   // ───────── View ───────────────────────────────────────────────
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
-      Text("Suggested Priorities")
-        .font(.headline)
-        .padding(.bottom, 4)
+      HStack {
+        Text("Suggested Priorities")
+          .font(.headline)
+        Spacer()
+        Button { showInfo = true } label: {
+          Image(systemName: "info.circle")
+            .font(.headline)
+            .foregroundColor(.white.opacity(0.6))
+        }
+      }
+      .padding(.bottom, 4)
 
       if vm.isLoading {
         ProgressView()
@@ -84,6 +93,9 @@ struct SuggestedPrioritiesView: View {
     .task(id: contextHash) { await vm.refresh() }
     .onAppear { if vm.priorities.isEmpty { Task { await vm.refresh() } } }
     .animation(.easeInOut, value: vm.priorities)
+    .sheet(isPresented: $showInfo) {
+      SuggestedPrioritiesInfoView()
+    }
     .sheet(item: $selectedForExplain) { p in
       let parts = p.text.components(separatedBy: .newlines)
       let header = parts.first ?? p.text


### PR DESCRIPTION
## Summary
- add `EnergyRingInfoView` describing how the dashboard ring works
- add `SuggestedPrioritiesInfoView` with template descriptions
- hook energy ring info icon to new view
- add info button to Suggested Priorities section

## Testing
- `swiftc -parse EnFlow/Views/Components/EnergyRingInfoView.swift`
- `swiftc -parse EnFlow/Views/Components/SuggestedPrioritiesInfoView.swift`
- `swiftc -parse EnFlow/Views/Components/EnergyRingView.swift`
- `swiftc -parse EnFlow/Views/Components/SuggestedPrioritiesView.swift`


------
https://chatgpt.com/codex/tasks/task_e_6861c64512ec832f8a5d3374e5e90e5b