### PR TITLE
Expand coming soon overlay

### DIFF
--- a/EnFlow/Views/OnboardingAndSettingsView.swift
+++ b/EnFlow/Views/OnboardingAndSettingsView.swift
@@ -116,14 +116,6 @@ struct OnboardingAndSettingsView: View {
     private var preferencesSection: some View {
         Section(header: Text("App Preferences")) {
             Toggle("Enable Notifications", isOn: .constant(false))
-                .disabled(true)
-                .overlay(
-                    ZStack {
-                        Color.gray.opacity(0.4)
-                        Text("Coming Soon")
-                            .foregroundColor(.blue)
-                    }
-                )
             Picker("GPT Tone", selection: $gptTone) {
                 Text("Wellness").tag("wellness")
                 Text("Scientific").tag("scientific")
@@ -131,6 +123,15 @@ struct OnboardingAndSettingsView: View {
             }
             .pickerStyle(.segmented)
         }
+        .disabled(true)
+        .overlay(
+            ZStack {
+                Color.black.opacity(0.6)
+                Text("Coming Soon")
+                    .font(.headline)
+                    .foregroundColor(.white)
+            }
+        )
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- expand overlay to cover entire preferences section
- darken overlay color and style text

## Testing
- `swift test` *(fails: `Could not find Package.swift`)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861c7543eb8832fa053bb365b172e1b