### PR TITLE
Implement daily feedback tracking

### DIFF
--- a/EnFlow/Models/EnergyInsightEngine.swift
+++ b/EnFlow/Models/EnergyInsightEngine.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+final class EnergyInsightEngine {
+    static let shared = EnergyInsightEngine()
+    private init() {}
+
+    private let calendar = Calendar.current
+
+    /// Basic correlations between daily feedback tags and health/calendar metrics.
+    func feedbackInsights(feedback: [DailyFeedback],
+                          health: [HealthEvent],
+                          events: [CalendarEvent]) -> [String] {
+        guard !feedback.isEmpty else { return [] }
+
+        func metrics(for day: Date) -> (sleep: Double?, hrv: Double?, meetings: Int) {
+            let h = health.first { calendar.isDate($0.date, inSameDayAs: day) }
+            let sleep = h.map { $0.deepSleep + $0.remSleep }
+            let hrv = h?.hrv
+            let meetings = events.filter {
+                calendar.isDate($0.startTime, inSameDayAs: day) &&
+                $0.eventTitle.lowercased().contains("meeting")
+            }.count
+            return (sleep, hrv, meetings)
+        }
+
+        func diff(_ a: [Double], _ b: [Double]) -> Double {
+            guard !a.isEmpty && !b.isEmpty else { return 0 }
+            let av = a.reduce(0, +) / Double(a.count)
+            let bv = b.reduce(0, +) / Double(b.count)
+            return av - bv
+        }
+
+        let highEnergyDays = feedback.filter(\.feltHighEnergy).map(\.date)
+        let lowEnergyDays = feedback.filter { !$0.feltHighEnergy }.map(\.date)
+        let stressDays = feedback.filter(\.feltStressed).map(\.date)
+        let calmDays = feedback.filter { !$0.feltStressed }.map(\.date)
+        let restDays = feedback.filter(\.feltWellRested).map(\.date)
+        let tiredDays = feedback.filter { !$0.feltWellRested }.map(\.date)
+
+        var lines: [String] = []
+
+        let sleepHigh = highEnergyDays.compactMap { metrics(for: $0).sleep }
+        let sleepLow = lowEnergyDays.compactMap { metrics(for: $0).sleep }
+        let sleepDiff = diff(sleepHigh, sleepLow)
+        if abs(sleepDiff) > 10 {
+            if sleepDiff > 0 {
+                lines.append("High energy days had \(Int(sleepDiff)) more mins of sleep")
+            } else {
+                lines.append("Low energy days slept \(Int(-sleepDiff)) mins less")
+            }
+        }
+
+        let hrvHigh = highEnergyDays.compactMap { metrics(for: $0).hrv }
+        let hrvLow = lowEnergyDays.compactMap { metrics(for: $0).hrv }
+        let hrvDiff = diff(hrvHigh, hrvLow)
+        if abs(hrvDiff) > 2 {
+            if hrvDiff > 0 {
+                lines.append("HRV was about \(Int(hrvDiff)) ms higher on high energy days")
+            } else {
+                lines.append("HRV dropped by \(Int(-hrvDiff)) ms on low energy days")
+            }
+        }
+
+        if !stressDays.isEmpty && !calmDays.isEmpty {
+            let meetStress = stressDays.reduce(0) { $0 + metrics(for: $1).meetings }
+            let meetCalm = calmDays.reduce(0) { $0 + metrics(for: $1).meetings }
+            let avgStress = Double(meetStress) / Double(stressDays.count)
+            let avgCalm = Double(meetCalm) / Double(calmDays.count)
+            let diffM = avgStress - avgCalm
+            if diffM > 0.5 {
+                lines.append("Stressful days had about \(Int(round(diffM))) more meetings")
+            }
+        }
+
+        let restGood = restDays.compactMap { metrics(for: $0).sleep }
+        let restBad = tiredDays.compactMap { metrics(for: $0).sleep }
+        let restDiff = diff(restGood, restBad)
+        if abs(restDiff) > 10 {
+            if restDiff > 0 {
+                lines.append("Well rested days included \(Int(restDiff)) more mins of sleep")
+            } else {
+                lines.append("Tired days slept \(Int(-restDiff)) mins less")
+            }
+        }
+
+        return lines
+    }
+}

--- a/EnFlow/Models/FeedbackStore.swift
+++ b/EnFlow/Models/FeedbackStore.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Combine
+
+@MainActor
+final class FeedbackStore: ObservableObject {
+    static let shared = FeedbackStore()
+
+    @Published private(set) var feedback: [DailyFeedback] = []
+
+    private init() { load() }
+
+    private var fileURL: URL {
+        let dir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        return dir.appendingPathComponent("DailyFeedback.json")
+    }
+
+    private func load() {
+        guard let data = try? Data(contentsOf: fileURL),
+              let decoded = try? JSONDecoder().decode([DailyFeedback].self, from: data) else { return }
+        feedback = decoded
+    }
+
+    private func persist() {
+        if let data = try? JSONEncoder().encode(feedback) {
+            try? data.write(to: fileURL, options: [.atomic])
+        }
+    }
+
+    func save(_ entry: DailyFeedback) {
+        let cal = Calendar.current
+        if let idx = feedback.firstIndex(where: { cal.isDate($0.date, inSameDayAs: entry.date) }) {
+            feedback[idx] = entry
+        } else {
+            feedback.append(entry)
+        }
+        persist()
+    }
+
+    func feedback(for date: Date) -> DailyFeedback? {
+        let cal = Calendar.current
+        return feedback.first { cal.isDate($0.date, inSameDayAs: date) }
+    }
+
+    func recent(days: Int) -> [DailyFeedback] {
+        let cal = Calendar.current
+        let start = cal.startOfDay(for: Date().addingTimeInterval(-Double(days - 1) * 86_400))
+        return feedback.filter { $0.date >= start }
+    }
+}

--- a/EnFlow/Models/UserFeedback.swift
+++ b/EnFlow/Models/UserFeedback.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+struct DailyFeedback: Identifiable, Codable {
+    let id: UUID
+    let date: Date
+    var feltHighEnergy: Bool
+    var feltStressed: Bool
+    var feltWellRested: Bool
+    var note: String?
+}

--- a/EnFlow/Views/Components/DailyFeedbackCard.swift
+++ b/EnFlow/Views/Components/DailyFeedbackCard.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+struct FeedbackToggle: View {
+    let icon: String
+    let label: String
+    @Binding var isOn: Bool
+
+    var body: some View {
+        Button(action: { withAnimation(.easeInOut(duration: 0.2)) { isOn.toggle() } }) {
+            VStack(spacing: 4) {
+                Image(systemName: icon)
+                    .font(.title2)
+                    .foregroundColor(isOn ? .yellow : .gray)
+                    .scaleEffect(isOn ? 1.2 : 1.0)
+                    .padding(12)
+                    .background(Circle().fill(isOn ? Color.yellow.opacity(0.25) : Color.gray.opacity(0.15)))
+                Text(label).font(.caption)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+struct DailyFeedbackCard: View {
+    @State private var energy = false
+    @State private var stress = false
+    @State private var sleep = false
+    @State private var note = ""
+    @State private var saved = false
+    @ObservedObject private var store = FeedbackStore.shared
+
+    private var today: Date { Calendar.current.startOfDay(for: Date()) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("How did today feel overall?")
+                .font(.headline)
+
+            HStack(spacing: 24) {
+                FeedbackToggle(icon: "bolt.fill", label: "Energy", isOn: $energy)
+                FeedbackToggle(icon: "exclamationmark.triangle.fill", label: "Stress", isOn: $stress)
+                FeedbackToggle(icon: "bed.double.fill", label: "Sleep", isOn: $sleep)
+            }
+
+            TextField("Add a note...", text: $note)
+                .textFieldStyle(.roundedBorder)
+
+            Button("Submit") {
+                let entry = DailyFeedback(id: UUID(),
+                                          date: today,
+                                          feltHighEnergy: energy,
+                                          feltStressed: stress,
+                                          feltWellRested: sleep,
+                                          note: note.isEmpty ? nil : note)
+                store.save(entry)
+                withAnimation { saved = true }
+                energy = false; stress = false; sleep = false; note = ""
+            }
+            .buttonStyle(.borderedProminent)
+
+            if saved {
+                Text("Saved!")
+                    .font(.footnote)
+                    .foregroundColor(.green)
+            }
+        }
+        .cardStyle(tint: 60)
+    }
+}

--- a/EnFlow/Views/DashboardView.swift
+++ b/EnFlow/Views/DashboardView.swift
@@ -140,6 +140,8 @@ struct DashboardView: View {
           SuggestedPrioritiesView(context: ctx)
         }
 
+        DailyFeedbackCard()
+
         Spacer(minLength: 40)
       }
       .padding(.top, headerPadding)


### PR DESCRIPTION
## Summary
- add `DailyFeedback` model and `FeedbackStore` for persistence
- implement simple correlation logic in `EnergyInsightEngine`
- add `DailyFeedbackCard` component for users to tag daily energy, stress and sleep
- display the feedback card at the bottom of `DashboardView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6861ca109f50832f924cc9a4573e449e