### PR TITLE
Fix layout for energy ring info page

### DIFF
--- a/EnFlow/Views/Components/EnergyRingInfoView.swift
+++ b/EnFlow/Views/Components/EnergyRingInfoView.swift
@@ -18,34 +18,31 @@ struct EnergyRingInfoView: View {
                         .buttonStyle(.borderedProminent)
                 }
                 .padding()
-                .background(.ultraThinMaterial)
                 .cornerRadius(20)
                 .padding()
             }
             .navigationTitle("Understanding Your Energy Rings")
             .toolbar { ToolbarItem(placement: .navigationBarTrailing) { Button("Done") { dismiss() } } }
             .sheet(isPresented: $showMore) { NavigationStack { MeetSolView() } }
+            .enflowBackground()
         }
     }
 
     private var ringStates: some View {
-        VStack(spacing: 16) {
-            ringRow(score: 25, title: "Low (0–40)", description: "Ring appears red/orange, sparse fill.")
-            ringRow(score: 55, title: "Moderate (40–65)", description: "Yellow, steady glow.")
-            ringRow(score: 78, title: "High (65–90)", description: "Vibrant green with pulse.")
-            ringRow(score: 95, title: "Supercharged (90–100)", description: "Blue-tinted white with glow.")
+        HStack(spacing: 20) {
+            ringExample(score: 25, label: "Low")
+            ringExample(score: 55, label: "Moderate")
+            ringExample(score: 78, label: "High")
+            ringExample(score: 95, label: "Super")
         }
+        .frame(maxWidth: .infinity)
     }
 
-    private func ringRow(score: Double, title: String, description: String) -> some View {
-        HStack(spacing: 16) {
-            EnergyRingView(score: score)
-                .frame(width: 60, height: 60)
-            VStack(alignment: .leading, spacing: 4) {
-                Text(title).font(.headline)
-                Text(description).font(.subheadline).foregroundColor(.secondary)
-            }
-            Spacer(minLength: 0)
+    private func ringExample(score: Double, label: String) -> some View {
+        VStack(spacing: 4) {
+            EnergyRingView(score: score, size: 60)
+            Text(label)
+                .font(.caption)
         }
     }
 

--- a/EnFlow/Views/Components/EnergyRingView.swift
+++ b/EnFlow/Views/Components/EnergyRingView.swift
@@ -16,6 +16,8 @@ struct EnergyRingView: View {
     var explainers: [String] = []
     /// Supply the timestamp from your parent (e.g. summary.date)
     var summaryDate: Date = Date()
+    /// Overall size for the ring (default 180 for full display)
+    var size: CGFloat = 180
 
     // ───────── Engine + State ──────────────────────────────────────
     @ObservedObject private var engine = EnergySummaryEngine.shared
@@ -129,8 +131,8 @@ struct EnergyRingView: View {
                 Spacer()
             }
         }
-        .frame(width: 180, height: 180)
-        .scaleEffect(baseScale * pulseScale)
+        .frame(width: size, height: size)
+        .scaleEffect((size / 180) * baseScale * pulseScale)
         .shadow(color: .black.opacity(0.35), radius: 8, x: 0, y: 4)
         .saturation(desaturate ? 0.55 : 1.0)
         .onReceive(engine.$refreshVersion.dropFirst()) { _ in


### PR DESCRIPTION
## Summary
- allow `EnergyRingView` to scale by adding a `size` parameter
- revise energy ring examples to be smaller and displayed horizontally
- use EnFlow gradient background on the info page

## Testing
- `swift test -q` *(fails: Could not find Package.swift)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862ede05744832f9da20ee938edb60c