### PR TITLE
Add template explainers for priority info

### DIFF
--- a/EnFlow/Models/SuggestedPrioritiesEngine.swift
+++ b/EnFlow/Models/SuggestedPrioritiesEngine.swift
@@ -26,6 +26,20 @@ enum PriorityTemplate: String, Codable, CaseIterable, Hashable, Identifiable {
         case .mindfulness: "sparkle"
         }
     }
+
+    /// User-facing title
+    var title: String { rawValue.capitalized }
+
+    /// Short explainer used in info views
+    var blurb: String {
+        switch self {
+        case .focus:       return "Deep work or tasks requiring high concentration."
+        case .movement:    return "Quick physical activity to boost energy."
+        case .rest:        return "Short rest strategies to recharge."
+        case .planning:    return "Light planning or admin work."
+        case .mindfulness: return "Mindfulness cues to reset your mind."
+        }
+    }
 }
 
 struct TemplatePrompt: Identifiable, Hashable, Codable {

--- a/EnFlow/Views/Components/ExplainSheetView.swift
+++ b/EnFlow/Views/Components/ExplainSheetView.swift
@@ -20,6 +20,8 @@ struct ExplainSheetView: View {
     let bullets: [String]
     /// When the data/prompt was generated
     let timestamp: Date
+    /// Optional template/category for suggestion explainers
+    var template: PriorityTemplate? = nil
 
     /// DateFormatter for the footer timestamp
     private static let dateFormatter: DateFormatter = {
@@ -31,6 +33,21 @@ struct ExplainSheetView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
+            if let template {
+                HStack(alignment: .top, spacing: 8) {
+                    Image(systemName: template.sfSymbol)
+                        .font(.title2)
+                        .foregroundColor(.accentColor)
+                        .frame(width: 28)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(template.title)
+                            .font(.headline)
+                        Text(template.blurb)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
             // Header
             Text(header)
                 .font(.title2).bold()

--- a/EnFlow/Views/Components/SuggestedPrioritiesInfoView.swift
+++ b/EnFlow/Views/Components/SuggestedPrioritiesInfoView.swift
@@ -8,7 +8,7 @@ struct SuggestedPrioritiesInfoView: View {
         NavigationStack {
             ScrollView {
                 VStack(alignment: .leading, spacing: 20) {
-                    ForEach(SuggestedPriorityTemplate.allCases) { t in
+                    ForEach(PriorityTemplate.allCases, id: \.\.self) { t in
                         priorityRow(t)
                     }
                     Divider()
@@ -28,33 +28,20 @@ struct SuggestedPrioritiesInfoView: View {
         }
     }
 
-    private func priorityRow(_ template: SuggestedPriorityTemplate) -> some View {
+    private func priorityRow(_ template: PriorityTemplate) -> some View {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: template.sfSymbol)
                 .font(.title2)
                 .frame(width: 32)
                 .foregroundColor(.accentColor)
             VStack(alignment: .leading, spacing: 4) {
-                Text(template.rawValue)
+                Text(template.title)
                     .font(.headline)
-                Text(blurb(for: template))
+                Text(template.blurb)
                     .font(.subheadline)
                     .foregroundColor(.secondary)
             }
             Spacer(minLength: 0)
-        }
-    }
-
-    private func blurb(for t: SuggestedPriorityTemplate) -> String {
-        switch t {
-        case .deepWork:           return "Best used during peak mental energy."
-        case .lightAdmin:         return "Great for lower focus periods."
-        case .activeRecovery:     return "Helps you bounce back after effort."
-        case .socialRecharge:     return "Connect with others to restore mood."
-        case .morningReflection:  return "Start your day with clarity."
-        case .windDown:           return "Ideal near bedtime or after intense sessions."
-        case .creativeSpur:       return "Suggested when mental energy is high but physical is moderate."
-        case .quickPhysicalReset: return "Short movement to perk up energy."
         }
     }
 }

--- a/EnFlow/Views/Components/SuggestedPrioritiesView.swift
+++ b/EnFlow/Views/Components/SuggestedPrioritiesView.swift
@@ -101,6 +101,7 @@ struct SuggestedPrioritiesView: View {
       let header = parts.first ?? p.text
       let bullets = p.rationale.components(separatedBy: "\n")
       ExplainSheetView(
+        template: p.template,
         header: header,
         bullets: bullets,
         timestamp: Date()


### PR DESCRIPTION
## Summary
- add `title` and `blurb` helpers to `PriorityTemplate`
- show template icon and summary in `ExplainSheetView`
- pass the template when presenting explain sheets
- align icons/descriptions in `SuggestedPrioritiesInfoView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6862ee7f785c832f93a3984e75e20bdd