### PR TITLE
Fix key path usage in SuggestedPrioritiesInfoView

### DIFF
--- a/EnFlow/Views/Components/SuggestedPrioritiesInfoView.swift
+++ b/EnFlow/Views/Components/SuggestedPrioritiesInfoView.swift
@@ -8,7 +8,7 @@ struct SuggestedPrioritiesInfoView: View {
         NavigationStack {
             ScrollView {
                 VStack(alignment: .leading, spacing: 20) {
-                    ForEach(PriorityTemplate.allCases, id: \.\.self) { t in
+                    ForEach(PriorityTemplate.allCases, id: \.self) { t in
                         priorityRow(t)
                     }
                     Divider()


### PR DESCRIPTION
## Summary
- correct the Swift key path used for identifying PriorityTemplate cases

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862fb140c2c832faca43b329a2c8809