### PR TITLE
Add CalendarEventClassifier heuristic

### DIFF
--- a/EnFlow/Models/CalendarEventClassifier.swift
+++ b/EnFlow/Models/CalendarEventClassifier.swift
@@ -1,0 +1,46 @@
+//
+//  CalendarEventClassifier.swift
+//  EnFlow
+//
+//  Created by OpenAI Assistant on 2025-06-18.
+//  Simple heuristic classifier for calendar events.
+//
+
+import Foundation
+
+/// Classifies a `CalendarEvent` as a "Booster", "Drainer" or "Neutral" with a confidence score.
+struct CalendarEventClassifier {
+    struct Result {
+        let label: String        // Booster, Drainer, Neutral
+        let confidence: Double   // 0.0 … 1.0
+    }
+
+    private let calendar = Calendar.current
+
+    func classify(_ event: CalendarEvent) -> Result {
+        let title = event.eventTitle.lowercased()
+        let duration = event.endTime.timeIntervalSince(event.startTime)
+        let hour = calendar.component(.hour, from: event.startTime)
+
+        // Booster heuristics -------------------------------------------------
+        if title.contains("walk") || title.contains("run") || title.contains("gym") {
+            let confidence = duration <= 3600 ? 0.8 : 0.6
+            return Result(label: "Booster", confidence: confidence)
+        }
+
+        // Drainer heuristics -------------------------------------------------
+        if title.contains("meeting") || title.contains("call") {
+            if duration >= 3600 && (12...17).contains(hour) {
+                return Result(label: "Drainer", confidence: 0.8)
+            } else if duration >= 1800 {
+                return Result(label: "Drainer", confidence: 0.6)
+            }
+        }
+        if duration > 7200 {
+            return Result(label: "Drainer", confidence: 0.5)
+        }
+
+        // Neutral fallback ---------------------------------------------------
+        return Result(label: "Neutral", confidence: 0.5)
+    }
+}

--- a/EnFlowTests/EnFlowTests.swift
+++ b/EnFlowTests/EnFlowTests.swift
@@ -50,4 +50,24 @@ struct EnFlowTests {
         #expect(text.contains("not really yaml"))
     }
 
+
+    @Test func classifierIdentifiesShortWalkAsBooster() throws {
+        let start = Date()
+        let end = start.addingTimeInterval(900) // 15 min
+        let event = CalendarEvent(eventTitle: "Afternoon Walk", startTime: start, endTime: end, isAllDay: false)
+        let result = CalendarEventClassifier().classify(event)
+        #expect(result.label == "Booster")
+        #expect(result.confidence > 0.7)
+    }
+
+    @Test func classifierIdentifiesLongAfternoonMeetingAsDrainer() throws {
+        let cal = Calendar.current
+        var comps = DateComponents(); comps.hour = 14
+        let start = cal.date(from: comps) ?? Date()
+        let end = start.addingTimeInterval(7200) // 2 h
+        let event = CalendarEvent(eventTitle: "Team Meeting", startTime: start, endTime: end, isAllDay: false)
+        let result = CalendarEventClassifier().classify(event)
+        #expect(result.label == "Drainer")
+        #expect(result.confidence >= 0.8)
+    }
 }


### PR DESCRIPTION
## Summary
- add a simple `CalendarEventClassifier` that flags calendar events as boosters, drainers, or neutral
- extend the unit tests with coverage for the new classifier

## Testing
- `swift test --disable-sandbox` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686414e44e10832fb03cbab25cb0c339