### PR TITLE
Add glow effect around forecast line

### DIFF
--- a/EnFlow/Views/Components/DailyEnergyForecastView.swift
+++ b/EnFlow/Views/Components/DailyEnergyForecastView.swift
@@ -34,9 +34,22 @@ struct DailyEnergyForecastView: View {
             let path = smoothPath(points)
             let stroke = StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round)
 
-            // gradient line
+            // gradient line with a subtle glow
             ColorPalette.verticalEnergyGradient
                 .mask(path.stroke(style: stroke))
+                .overlay(
+                    // soft glow following the curve
+                    ColorPalette.verticalEnergyGradient
+                        .mask(
+                            path.stroke(
+                                style: StrokeStyle(lineWidth: 6,
+                                                   lineCap: .round,
+                                                   lineJoin: .round)
+                            )
+                        )
+                        .blur(radius: 3)
+                        .opacity(0.7)
+                )
                 .overlay(
                     ColorPalette.gradient(for: average(clamped) * 100)
                         .mask(path.stroke(style: stroke))


### PR DESCRIPTION
## Summary
- enhance daily forecast chart with glow

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686420c783d8832f803d9368e9d81bd5