### PR TITLE
Apply embossed styling to info buttons

### DIFF
--- a/EnFlow/Utilities/EmbossedInfoButtonStyle.swift
+++ b/EnFlow/Utilities/EmbossedInfoButtonStyle.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+/// Button style for ℹ️ icons with an embossed look.
+struct EmbossedInfoButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .foregroundColor(.white.opacity(0.7))
+            .padding(6)
+            .background(
+                Circle()
+                    .fill(Color.white.opacity(0.15))
+                    .shadow(color: .black.opacity(0.4), radius: configuration.isPressed ? 1 : 2, x: 1, y: 1)
+                    .shadow(color: .white.opacity(0.4), radius: configuration.isPressed ? 1 : 2, x: -1, y: -1)
+            )
+            .clipShape(Circle())
+    }
+}
+
+extension ButtonStyle where Self == EmbossedInfoButtonStyle {
+    static var embossedInfo: EmbossedInfoButtonStyle { EmbossedInfoButtonStyle() }
+}

--- a/EnFlow/Views/Components/EnergyRingView.swift
+++ b/EnFlow/Views/Components/EnergyRingView.swift
@@ -125,14 +125,11 @@ struct EnergyRingView: View {
             VStack {
                 HStack {
                     Spacer()
-                    Button {
-                        showExplanation = true
-                    } label: {
+                    Button { showExplanation = true } label: {
                         Image(systemName: "info.circle")
                             .font(.headline)
-                            .foregroundColor(.white.opacity(0.5))
                     }
-                    .padding(6)
+                    .buttonStyle(.embossedInfo)
                 }
                 Spacer()
             }

--- a/EnFlow/Views/Components/SuggestedPrioritiesView.swift
+++ b/EnFlow/Views/Components/SuggestedPrioritiesView.swift
@@ -37,8 +37,8 @@ struct SuggestedPrioritiesView: View {
         Button { showInfo = true } label: {
           Image(systemName: "info.circle")
             .font(.headline)
-            .foregroundColor(.white.opacity(0.6))
         }
+        .buttonStyle(.embossedInfo)
       }
       .padding(.bottom, 4)
 
@@ -80,8 +80,8 @@ struct SuggestedPrioritiesView: View {
               Image(systemName: "info.circle")
                 .font(.headline)
                 .padding(8)
-                .foregroundColor(.white.opacity(0.6))
             }
+            .buttonStyle(.embossedInfo)
           }
         }
       } else {


### PR DESCRIPTION
## Summary
- add `EmbossedInfoButtonStyle` for raised info icons
- use the new style on EnergyRingView and SuggestedPrioritiesView buttons

## Testing
- `xcodebuild -list -project EnFlow.xcodeproj` *(fails: command not found)*
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_686420d612bc832fb7a25fc091b35a27