### PR TITLE
Add glowing shimmer to active tab icon

### DIFF
--- a/EnFlow/Views/Components/ShimmerModifier.swift
+++ b/EnFlow/Views/Components/ShimmerModifier.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+/// Applies a shimmering highlight animation.
+struct ShimmerModifier: ViewModifier {
+    @State private var phase: CGFloat = -1
+    func body(content: Content) -> some View {
+        content
+            .overlay {
+                LinearGradient(
+                    gradient: Gradient(colors: [Color.white.opacity(0.0), Color.white.opacity(0.8), Color.white.opacity(0.0)]),
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+                .rotationEffect(.degrees(30))
+                .offset(x: phase * 200)
+                .blendMode(.plusLighter)
+                .mask(content)
+            }
+            .onAppear {
+                withAnimation(.linear(duration: 1.2).repeatForever(autoreverses: false)) {
+                    phase = 1
+                }
+            }
+    }
+}
+
+extension View {
+    /// Shimmering effect overlay.
+    func shimmering() -> some View {
+        modifier(ShimmerModifier())
+    }
+}

--- a/EnFlow/Views/Components/TabBarLabel.swift
+++ b/EnFlow/Views/Components/TabBarLabel.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+/// Tab item label that highlights the active icon.
+struct TabBarLabel: View {
+    let title: String
+    let systemImage: String
+    let index: Int
+    @Binding var selection: Int
+
+    var body: some View {
+        Label(title, systemImage: systemImage)
+            .modifier(ActiveHighlight(isActive: selection == index))
+    }
+}
+
+private struct ActiveHighlight: ViewModifier {
+    var isActive: Bool
+    func body(content: Content) -> some View {
+        if isActive {
+            content
+                .foregroundColor(.orange)
+                .shimmering()
+                .shadow(color: .orange.opacity(0.9), radius: 6)
+        } else {
+            content
+        }
+    }
+}

--- a/EnFlow/Views/MainShellView.swift
+++ b/EnFlow/Views/MainShellView.swift
@@ -23,22 +23,30 @@ struct MainShellView: View {
             TabView(selection: $selection) {
                 NavigationView { DashboardView() }
                     .id(tabIDs[0]!)
-                    .tabItem { Label("Dashboard", systemImage: "waveform.path.ecg") }
+                    .tabItem {
+                        TabBarLabel(title: "Dashboard", systemImage: "waveform.path.ecg", index: 0, selection: $selection)
+                    }
                     .tag(0)
 
                 NavigationView { CalendarRootView() }
                     .id(tabIDs[1]!)
-                    .tabItem { Label("Calendar", systemImage: "calendar") }
+                    .tabItem {
+                        TabBarLabel(title: "Calendar", systemImage: "calendar", index: 1, selection: $selection)
+                    }
                     .tag(1)
 
                 NavigationView { TrendsView() }
                     .id(tabIDs[2]!)
-                    .tabItem { Label("Trends", systemImage: "chart.bar.fill") }
+                    .tabItem {
+                        TabBarLabel(title: "Trends", systemImage: "chart.bar.fill", index: 2, selection: $selection)
+                    }
                     .tag(2)
 
                 NavigationView { UserProfileSummaryView() }
                     .id(tabIDs[3]!)
-                    .tabItem { Label("User", systemImage: "person.crop.circle") }
+                    .tabItem {
+                        TabBarLabel(title: "User", systemImage: "person.crop.circle", index: 3, selection: $selection)
+                    }
                     .tag(3)
             }
             .onChange(of: selection) { newValue in


### PR DESCRIPTION
## Summary
- create `ShimmerModifier` view modifier for shimmering overlay
- add `TabBarLabel` that applies shimmer and orange glow when active
- update `MainShellView` to use new `TabBarLabel`

## Testing
- `xcodebuild -list -project EnFlow.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864211192a4832f97dcdc51f586b539