### PR TITLE
Adjust info popup UI

### DIFF
--- a/EnFlow/Views/Components/EnergyRingInfoView.swift
+++ b/EnFlow/Views/Components/EnergyRingInfoView.swift
@@ -21,7 +21,7 @@ struct EnergyRingInfoView: View {
                 .cornerRadius(20)
                 .padding()
             }
-            .navigationTitle("Understanding Your Energy Rings")
+            .navigationTitle("Your Energy Score")
             .toolbar { ToolbarItem(placement: .navigationBarTrailing) { Button("Done") { dismiss() } } }
             .sheet(isPresented: $showMore) { NavigationStack { MeetSolView() } }
             .enflowBackground()
@@ -40,7 +40,7 @@ struct EnergyRingInfoView: View {
 
     private func ringExample(score: Double, label: String) -> some View {
         VStack(spacing: 4) {
-            EnergyRingView(score: score, size: 60)
+            EnergyRingView(score: score, size: 60, showInfoButton: false)
             Text(label)
                 .font(.caption)
         }

--- a/EnFlow/Views/Components/EnergyRingView.swift
+++ b/EnFlow/Views/Components/EnergyRingView.swift
@@ -20,6 +20,8 @@ struct EnergyRingView: View {
     var summaryDate: Date = Date()
     /// Overall size for the ring (default 180 for full display)
     var size: CGFloat = 180
+    /// Show the small info button that brings up the explainer sheet
+    var showInfoButton: Bool = true
 
     // ───────── Engine + State ──────────────────────────────────────
     @ObservedObject private var engine = EnergySummaryEngine.shared
@@ -121,20 +123,22 @@ struct EnergyRingView: View {
                     .transition(.scale.combined(with: .opacity))
             }
 
-            // — Info button (top-right) —
-            VStack {
-                HStack {
-                    Spacer()
-                    Button {
-                        showExplanation = true
-                    } label: {
-                        Image(systemName: "info.circle")
-                            .font(.headline)
-                            .foregroundColor(.white.opacity(0.5))
+            if showInfoButton {
+                // — Info button (top-right) —
+                VStack {
+                    HStack {
+                        Spacer()
+                        Button {
+                            showExplanation = true
+                        } label: {
+                            Image(systemName: "info.circle")
+                                .font(.headline)
+                                .foregroundColor(.white.opacity(0.5))
+                        }
+                        .padding(6)
                     }
-                    .padding(6)
+                    Spacer()
                 }
-                Spacer()
             }
         }
         .frame(width: size, height: size)


### PR DESCRIPTION
## Summary
- rename the EnergyRingInfoView title to "Your Energy Score"
- add a flag to EnergyRingView to toggle the info button
- hide the info button on ring examples in the info popup

## Testing
- `xcodebuild -list -project EnFlow.xcodeproj | head -n 20` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686421f04ab0832f84617bfcb094613f