### PR TITLE
Update energy ring info view

### DIFF
--- a/EnFlow/Views/Components/EnergyRingInfoView.swift
+++ b/EnFlow/Views/Components/EnergyRingInfoView.swift
@@ -21,7 +21,7 @@ struct EnergyRingInfoView: View {
                 .cornerRadius(20)
                 .padding()
             }
-            .navigationTitle("Understanding Your Energy Rings")
+            .navigationTitle("Your Energy Score")
             .toolbar { ToolbarItem(placement: .navigationBarTrailing) { Button("Done") { dismiss() } } }
             .sheet(isPresented: $showMore) { NavigationStack { MeetSolView() } }
             .enflowBackground()
@@ -40,7 +40,7 @@ struct EnergyRingInfoView: View {
 
     private func ringExample(score: Double, label: String) -> some View {
         VStack(spacing: 4) {
-            EnergyRingView(score: score, size: 60)
+            EnergyRingView(score: score, size: 60, showInfoButton: false)
             Text(label)
                 .font(.caption)
         }

--- a/EnFlow/Views/Components/EnergyRingView.swift
+++ b/EnFlow/Views/Components/EnergyRingView.swift
@@ -22,6 +22,8 @@ struct EnergyRingView: View {
     var summaryDate: Date = Date()
     /// Overall size for the ring (default 180 for full display)
     var size: CGFloat = 180
+    /// Show the info button that presents additional details
+    var showInfoButton: Bool = true
 
     // ───────── Engine + State ──────────────────────────────────────
     @ObservedObject private var engine = EnergySummaryEngine.shared
@@ -147,16 +149,18 @@ struct EnergyRingView: View {
             }
 
             // — Info button (top-right) —
-            VStack {
-                HStack {
-                    Spacer()
-                    Button { showExplanation = true } label: {
-                        Image(systemName: "info.circle")
-                            .font(.headline)
+            if showInfoButton {
+                VStack {
+                    HStack {
+                        Spacer()
+                        Button { showExplanation = true } label: {
+                            Image(systemName: "info.circle")
+                                .font(.headline)
+                        }
+                        .buttonStyle(.embossedInfo)
                     }
-                    .buttonStyle(.embossedInfo)
+                    Spacer()
                 }
-                Spacer()
             }
         }
         .frame(width: size, height: size)


### PR DESCRIPTION
## Summary
- rename energy pop-up title to "Your Energy Score"
- hide info buttons in energy ring examples
- add configurable `showInfoButton` option to `EnergyRingView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68642427daa0832fb590656c5e91c763