### PR TITLE
Fix simulated health dates

### DIFF
--- a/EnFlow/Health/SimulatedHealthLoader.swift
+++ b/EnFlow/Health/SimulatedHealthLoader.swift
@@ -39,16 +39,23 @@ struct SimulatedHealthLoader {
         }
 
         let sortedDays = byDay.keys.sorted()
+        guard let lastDay = sortedDays.last else { return [] }
+        let today = cal.startOfDay(for: Date())
+        let offset = cal.dateComponents([.day], from: lastDay, to: today).day ?? 0
+
         let startIndex = max(0, sortedDays.count - daysBack)
         return sortedDays[startIndex...].compactMap { day in
-            guard let acc = byDay[day] else { return nil }
+            guard let acc = byDay[day],
+                  let shifted = cal.date(byAdding: .day, value: offset, to: day) else {
+                return nil
+            }
             let steps = acc.steps
             let restHR = acc.restHRCount > 0 ? acc.restHRTotal / Double(acc.restHRCount) : 0
             let hrv = acc.hrvCount > 0 ? acc.hrvTotal / Double(acc.hrvCount) : 0
             let eff = acc.sleepEffCount > 0 ? acc.sleepEffTotal / Double(acc.sleepEffCount) : 0
             let lat = acc.sleepLatCount > 0 ? acc.sleepLatTotal / Double(acc.sleepLatCount) : 0
             return HealthEvent(
-                date: day,
+                date: shifted,
                 hrv: hrv,
                 restingHR: restHR,
                 sleepEfficiency: eff,


### PR DESCRIPTION
## Summary
- adjust `SimulatedHealthLoader` so simulated data aligns with today

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project EnFlow.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68642705e18c832f84b2340ceb520dac