### PR TITLE
Fix energy ring shimmer artifacting

### DIFF
--- a/EnFlow/Utilities/ViewExtensions.swift
+++ b/EnFlow/Utilities/ViewExtensions.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+extension View {
+    /// Applies `transform` to the view if `condition` is true.
+    @ViewBuilder
+    func applyIf<T: View>(_ condition: Bool, transform: (Self) -> T) -> some View {
+        if condition {
+            transform(self)
+        } else {
+            self
+        }
+    }
+}
+

--- a/EnFlow/Views/Components/EnergyRingView.swift
+++ b/EnFlow/Views/Components/EnergyRingView.swift
@@ -31,7 +31,6 @@ struct EnergyRingView: View {
     @State private var showExplanation = false
     @State private var ringProgress: Double = 0
     @State private var hasAnimated = false
-    @State private var shimmerAngle: Double = 0
 
     // Base scale applied so the composite ring appears slightly smaller
     private let baseScale: CGFloat = 0.9
@@ -84,28 +83,9 @@ struct EnergyRingView: View {
                                                dash: dashed ? [4, 2] : []))
                     .rotationEffect(.degrees(-90))
                     .animation(.easeOut(duration: 0.8), value: ringProgress)
-                    .overlay(
-                        Group {
-                            if shimmer {
-                                Circle()
-                                    .trim(from: 0, to: CGFloat(ringProgress))
-                                    .stroke(
-                                        AngularGradient(
-                                            gradient: Gradient(colors: [
-                                                .white.opacity(0.0),
-                                                .white.opacity(0.4),
-                                                .white.opacity(0.0)
-                                            ]),
-                                            center: .center,
-                                            angle: .degrees(shimmerAngle)
-                                        ),
-                                        style: StrokeStyle(lineWidth: 20, lineCap: .round)
-                                    )
-                                    .rotationEffect(.degrees(-90))
-                                    .blendMode(.screen)
-                            }
-                        }
-                    )
+                    .applyIf(shimmer) { view in
+                        view.shimmering()
+                    }
 
                 // — Label —
                 VStack(spacing: 4) {
@@ -183,12 +163,6 @@ struct EnergyRingView: View {
                 hasAnimated = true
             } else {
                 ringProgress = sc / 100
-            }
-            if shimmer {
-                shimmerAngle = 0
-                withAnimation(.linear(duration: 5).repeatForever(autoreverses: false)) {
-                    shimmerAngle = 360
-                }
             }
         }
         .onChange(of: score) { newValue in


### PR DESCRIPTION
## Summary
- add a small View extension for conditional modifiers
- use the ShimmerModifier via `applyIf` instead of custom overlay

## Testing
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686428ef6068832fa304c7371c733a25