### PR TITLE
Fix oversized info button shadows

### DIFF
--- a/EnFlow/Utilities/EmbossedInfoButtonStyle.swift
+++ b/EnFlow/Utilities/EmbossedInfoButtonStyle.swift
@@ -5,7 +5,8 @@ struct EmbossedInfoButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .foregroundColor(.white.opacity(0.7))
-            .padding(6)
+            // Tighter padding so the embossed circle hugs the icon
+            .padding(4)
             .background(
                 Circle()
                     .fill(Color.white.opacity(0.15))

--- a/EnFlow/Views/Components/SuggestedPrioritiesView.swift
+++ b/EnFlow/Views/Components/SuggestedPrioritiesView.swift
@@ -79,7 +79,8 @@ struct SuggestedPrioritiesView: View {
             } label: {
               Image(systemName: "info.circle")
                 .font(.headline)
-                .padding(8)
+                // Smaller padding so the embossed background matches other info buttons
+                .padding(4)
             }
             .buttonStyle(.embossedInfo)
           }


### PR DESCRIPTION
## Summary
- adjust `EmbossedInfoButtonStyle` padding so the embossed halo is tighter
- align info button padding in `SuggestedPrioritiesView` with other buttons

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864292bd328832f9ad7ef4b23c36674