### PR TITLE
Improve energy ring shimmer

### DIFF
--- a/EnFlow/Views/Components/EnergyRingView.swift
+++ b/EnFlow/Views/Components/EnergyRingView.swift
@@ -84,7 +84,7 @@ struct EnergyRingView: View {
                     .rotationEffect(.degrees(-90))
                     .animation(.easeOut(duration: 0.8), value: ringProgress)
                     .applyIf(shimmer) { view in
-                        view.shimmering()
+                        view.shimmering(duration: 2.4)
                     }
 
                 // — Label —

--- a/EnFlow/Views/Components/ShimmerModifier.swift
+++ b/EnFlow/Views/Components/ShimmerModifier.swift
@@ -3,21 +3,27 @@ import SwiftUI
 /// Applies a shimmering highlight animation.
 struct ShimmerModifier: ViewModifier {
     @State private var phase: CGFloat = -1
+    /// Length in seconds for one pass of the shimmer animation.
+    var duration: Double = 1.2
+
     func body(content: Content) -> some View {
         content
             .overlay {
                 LinearGradient(
-                    gradient: Gradient(colors: [Color.white.opacity(0.0), Color.white.opacity(0.8), Color.white.opacity(0.0)]),
+                    gradient: Gradient(colors: [Color.white.opacity(0.0),
+                                              Color.white.opacity(0.8),
+                                              Color.white.opacity(0.0)]),
                     startPoint: .topLeading,
                     endPoint: .bottomTrailing
                 )
                 .rotationEffect(.degrees(30))
-                .offset(x: phase * 200)
+                .offset(x: phase * 250)
                 .blendMode(.plusLighter)
                 .mask(content)
             }
             .onAppear {
-                withAnimation(.linear(duration: 1.2).repeatForever(autoreverses: false)) {
+                withAnimation(.linear(duration: duration)
+                    .repeatForever(autoreverses: false)) {
                     phase = 1
                 }
             }
@@ -26,7 +32,7 @@ struct ShimmerModifier: ViewModifier {
 
 extension View {
     /// Shimmering effect overlay.
-    func shimmering() -> some View {
-        modifier(ShimmerModifier())
+    func shimmering(duration: Double = 1.2) -> some View {
+        modifier(ShimmerModifier(duration: duration))
     }
 }


### PR DESCRIPTION
## Summary
- make shimmer modifier configurable
- slow down the energy ring shimmer and use a larger gradient offset

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_68642b330e90832f8a224fae6a8aecb8