### PR TITLE
Dim dashboard picker when scrolling

### DIFF
--- a/EnFlow/Views/DashboardView.swift
+++ b/EnFlow/Views/DashboardView.swift
@@ -41,6 +41,12 @@ struct DashboardView: View {
 
   private typealias EnergyParts = EnergyForecastModel.EnergyParts
 
+  /// Opacity for the Today/Tomorrow picker. Dims slightly when scrolled.
+  private var pickerOpacity: Double {
+    let base = 1 + Double(scrollOffset / 80)
+    return min(1, max(0.5, base))
+  }
+
   // MARK: Root view ----------------------------------------------------------
   var body: some View {
     ZStack {
@@ -70,6 +76,8 @@ struct DashboardView: View {
       .frame(width: 180)
       .padding(.trailing, 16)
       .padding(.top, pickerTop)
+      .opacity(pickerOpacity)
+      .animation(.easeInOut(duration: 0.2), value: pickerOpacity)
     }
     // Soft haptic on tab switch
     .onChange(of: selection) { _ in


### PR DESCRIPTION
## Summary
- adjust DashboardView to dim the Today/Tomorrow segmented control when the scroll view is offset

## Testing
- `xcodebuild -list -project EnFlow.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68642be8251c832fb02158411802bd15