### PR TITLE
Increase EnergyLineChartView height

### DIFF
--- a/EnFlow/Views/Components/EnergyLineChartView.swift
+++ b/EnFlow/Views/Components/EnergyLineChartView.swift
@@ -30,7 +30,7 @@ struct EnergyLineChartView: View {
                         .blendMode(.overlay)
                 )
         }
-        .frame(height: 60)
+        .frame(minHeight: 80, idealHeight: 120)
     }
 
     private func average(_ values: [Double]) -> Double {

--- a/EnFlow/Views/MeetSolView.swift
+++ b/EnFlow/Views/MeetSolView.swift
@@ -109,7 +109,7 @@ struct MeetSolView: View {
                 Text("Sol doesn’t just reflect your current energy — it forecasts what’s ahead.")
                     .font(.body)
                 EnergyLineChartView(values: sampleWave)
-                    .frame(height: 60)
+                    .frame(minHeight: 80, idealHeight: 120)
                 VStack(alignment: .leading, spacing: 8) {
                     Label("Uses your past 7–14 days of biometric data", systemImage: "clock.arrow.circlepath")
                     Label("Applies circadian modeling to adjust by time of day", systemImage: "sunrise.fill")


### PR DESCRIPTION
## Summary
- expand EnergyLineChartView to use a flexible frame
- remove fixed size in MeetSolView's chart

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -scheme EnFlow -project EnFlow.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 15'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68643cfdb76c832fbb0149dde08eb771