### PR TITLE
Fix tomorrow forecast missing data issue

### DIFF
--- a/EnFlow/Models/EnergyForecastModel.swift
+++ b/EnFlow/Models/EnergyForecastModel.swift
@@ -59,7 +59,7 @@ final class EnergyForecastModel: ObservableObject {
     }
 
     let history = health.filter { $0.date <= date }
-    guard let hSample = history.first(where: { calendar.isDate($0.date, inSameDayAs: date) }) else {
+    guard let hSample = history.first(where: { calendar.isDate($0.date, inSameDayAs: date) }) ?? history.last else {
       return nil
     }
 

--- a/EnFlow/Views/DashboardView.swift
+++ b/EnFlow/Views/DashboardView.swift
@@ -263,7 +263,7 @@ struct DashboardView: View {
     let tomorrow = cal.startOfDay(for: Date().addingTimeInterval(86_400))
 
     // Health + calendar pulls
-    let healthList = await HealthDataPipeline.shared.fetchDailyHealthEvents(daysBack: 2)
+    let healthList = await HealthDataPipeline.shared.fetchDailyHealthEvents(daysBack: 14)
     let steps = await HealthDataPipeline.shared.stepsToday()
     let eventsToday = await CalendarDataPipeline.shared.fetchEvents(for: today)
     let eventsTomorrow = await CalendarDataPipeline.shared.fetchEvents(for: tomorrow)
@@ -289,9 +289,8 @@ struct DashboardView: View {
         profile: profile)?.confidenceScore ?? 0
 
     let todayHealth = healthList.first { cal.isDate($0.date, inSameDayAs: today) }
-    let tomorrowHealth = healthList.first { cal.isDate($0.date, inSameDayAs: tomorrow) }
     let noToday = !(todayHealth?.hasSamples ?? false)
-    let noTomorrow = !(tomorrowHealth?.hasSamples ?? false)
+    let noTomorrow = forecastConf == 0
 
     // 3-part slices
     func slices(from wave: [Double]) -> EnergyForecastModel.EnergyParts {


### PR DESCRIPTION
## Summary
- use the latest available HealthEvent when forecasting a future day
- fetch 14 days of health history in `DashboardView.loadData`
- determine missing data on tomorrow screen based on forecast availability

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68643d6be2e4832f961cca23d9ac3ec5