### PR TITLE
Add Calendar insights popup view

### DIFF
--- a/EnFlow/Views/Components/CalendarInsightsPopup.swift
+++ b/EnFlow/Views/Components/CalendarInsightsPopup.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// Compact popup displaying calendar-related insights.
+struct CalendarInsightsPopup: View {
+    @ObservedObject var viewModel: CalendarInsightsViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .topTrailing) {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 12) {
+                        ForEach(viewModel.insights, id: \.self) { line in
+                            InsightBannerView(text: line)
+                        }
+                    }
+                    .padding()
+                }
+                Button("Close") { dismiss() }
+                    .padding()
+            }
+            .frame(width: proxy.size.width * 0.9)
+            .frame(height: proxy.size.height * 0.45)
+            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+            .cornerRadius(20)
+            .shadow(radius: 20)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .enflowBackground()
+        }
+    }
+}
+
+#Preview {
+    class PreviewModel: CalendarInsightsViewModel, ObservableObject {
+        @Published var insights: [String] = [
+            "Your afternoon meetings often align with energy lows.",
+            "Days with >7h sleep show a 15% boost in energy."
+        ]
+    }
+    return CalendarInsightsPopup(viewModel: PreviewModel())
+}


### PR DESCRIPTION
## Summary
- add `CalendarInsightsPopup` for scrollable list of insights

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project EnFlow.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864470b9e48832fbb1e4f33a9fd79fc