### PR TITLE
Add CalendarInsightsViewModel

### DIFF
--- a/EnFlow/Models/CalendarInsightsViewModel.swift
+++ b/EnFlow/Models/CalendarInsightsViewModel.swift
@@ -1,0 +1,46 @@
+//
+//  CalendarInsightsViewModel.swift
+//  EnFlow
+//
+//  Created by Codex.
+//
+
+import Foundation
+
+@MainActor
+class CalendarInsightsViewModel: ObservableObject {
+    @Published var insights: [String] = []
+
+    /// Generates insight text for each detected pattern using GPT and
+    /// appends unique, confidence-sorted lines to ``insights``.
+    func loadInsights(from patterns: [DetectedPattern]) async {
+        guard !patterns.isEmpty else { return }
+
+        let results = await withTaskGroup(of: (String, Double).self) { group in
+            for pattern in patterns {
+                group.addTask {
+                    let text = await generateGPTInsight(from: pattern)
+                    return (text, pattern.confidence)
+                }
+            }
+
+            var collected: [(String, Double)] = []
+            for await res in group { collected.append(res) }
+            return collected
+        }
+
+        // Deduplicate keeping the highest confidence per text
+        var unique: [String: Double] = [:]
+        for (text, conf) in results {
+            if let existing = unique[text] {
+                if conf > existing { unique[text] = conf }
+            } else {
+                unique[text] = conf
+            }
+        }
+
+        let sorted = unique.sorted { $0.value > $1.value }.map { $0.key }
+        insights.append(contentsOf: sorted)
+    }
+}
+


### PR DESCRIPTION
## Summary
- create `CalendarInsightsViewModel` for CalendarInsightsPopup
- gather GPT-based insights for detected patterns with optional dedupe & sort

## Testing
- `xcodebuild -project EnFlow.xcodeproj -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644a0fd6a8832f97af993823c6df28