### PR TITLE
Integrate calendar insights popup

### DIFF
--- a/EnFlow/Views/CalendarRootView.swift
+++ b/EnFlow/Views/CalendarRootView.swift
@@ -13,11 +13,24 @@ enum CalendarMode: String, CaseIterable, Identifiable {
 
 struct CalendarRootView: View {
     @State private var mode: CalendarMode = .day
+    @State private var showInsights = false
+    @StateObject private var insightsModel = CalendarInsightsViewModel()
 
     var body: some View {
         VStack(spacing: 0) {
-            // Dropdown Header — Top Right
+            // Dropdown Header — Top Right + Insights button
             HStack {
+                Button {
+                    showInsights = true
+                } label: {
+                    Image(systemName: "lightbulb")
+                        .font(.title3)
+                        .padding(8)
+                }
+                .sheet(isPresented: $showInsights) {
+                    CalendarInsightsPopup(viewModel: insightsModel)
+                        .presentationDetents([.medium])
+                }
                 Spacer()
                 Menu {
                     ForEach(CalendarMode.allCases) { option in
@@ -44,9 +57,9 @@ struct CalendarRootView: View {
                             .shadow(radius: 2)
                     )
                 }
-                .padding(.top, 12)
-                .padding(.trailing, 20)
             }
+            .padding(.top, 12)
+            .padding(.horizontal, 20)
 
             // Dynamic View Injection
             switch mode {
@@ -64,6 +77,34 @@ struct CalendarRootView: View {
         .enflowBackground()
         .animation(.easeInOut(duration: 0.25), value: mode)
         .edgesIgnoringSafeArea(.bottom)
+        .task { await loadInsights() }
+    }
+
+    private func loadInsights() async {
+        let cal = Calendar.current
+        let end = cal.startOfDay(for: Date())
+        guard let start = cal.date(byAdding: .day, value: -30, to: end) else { return }
+
+        let health = await HealthDataPipeline.shared.fetchDailyHealthEvents(daysBack: 30)
+        let events = await CalendarDataPipeline.shared.fetchEvents(start: start, end: end)
+
+        var summaries: [DayEnergySummary] = []
+        for offset in 0..<30 {
+            if let day = cal.date(byAdding: .day, value: offset, to: start) {
+                let h = health.filter { cal.isDate($0.date, inSameDayAs: day) }
+                let e = events.filter { cal.isDate($0.startTime, inSameDayAs: day) }
+                let profile = UserProfileStore.load()
+                let summary = UnifiedEnergyModel.shared.summary(for: day,
+                                                               healthEvents: h,
+                                                               calendarEvents: e,
+                                                               profile: profile)
+                summaries.append(summary)
+            }
+        }
+
+        let patterns = PatternDetectionEngine().detectPatterns(events: events,
+                                                               summaries: summaries)
+        await insightsModel.loadInsights(from: patterns)
     }
 }
 


### PR DESCRIPTION
## Summary
- add `CalendarInsightsViewModel` to `CalendarRootView`
- show lightbulb button that opens `CalendarInsightsPopup`
- load recent calendar patterns on view load

## Testing
- `swift test -c release` *(fails: `Could not find Package.swift`)*
- `xcodebuild -list -project EnFlow.xcodeproj` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68644e204d14832f8fef6379cf2fc1bd