### PR TITLE
Fix line graph gesture modifiers placement

### DIFF
--- a/EnFlow/Views/Components/DailyEnergyForecastView.swift
+++ b/EnFlow/Views/Components/DailyEnergyForecastView.swift
@@ -126,31 +126,31 @@ struct DailyEnergyForecastView: View {
                         .transition(.opacity)
                 }
             }
-            .frame(height: 80)
-            .contentShape(Rectangle())
-            .gesture(
-                DragGesture(minimumDistance: 0)
-                    .onChanged { value in
-                        dragging = true
-                        let x = min(max(0, value.location.x), width)
-                        let idx = Int(round(x / width * CGFloat(max(count - 1, 1))))
-                        if idx != activeIndex {
-                            activeIndex = idx
-                        }
-                    }
-                    .onEnded { _ in
-                        dragging = false
-                        withAnimation(.easeOut(duration: 0.2)) { activeIndex = nil }
-                    }
-            )
-#if !os(iOS)
-            .onHover { inside in
-                if !inside && !dragging {
-                    activeIndex = nil
-                }
-            }
-#endif
         }
+        .frame(height: 80)
+        .contentShape(Rectangle())
+        .gesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { value in
+                    dragging = true
+                    let x = min(max(0, value.location.x), width)
+                    let idx = Int(round(x / width * CGFloat(max(count - 1, 1))))
+                    if idx != activeIndex {
+                        activeIndex = idx
+                    }
+                }
+                .onEnded { _ in
+                    dragging = false
+                    withAnimation(.easeOut(duration: 0.2)) { activeIndex = nil }
+                }
+        )
+#if !os(iOS)
+        .onHover { inside in
+            if !inside && !dragging {
+                activeIndex = nil
+            }
+        }
+#endif
     }
 
     private func average(_ vals: [Double]) -> Double {


### PR DESCRIPTION
## Summary
- move frame, contentShape, gesture and hover modifiers outside GeometryReader in `DailyEnergyForecastView`

## Testing
- `xcodebuild -list -project EnFlow.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686452b13114832f87e91a06418e7149