### PR TITLE
Fix DayView energy display and improve Week view

### DIFF
--- a/EnFlow/Views/Components/DayView.swift
+++ b/EnFlow/Views/Components/DayView.swift
@@ -368,7 +368,8 @@ struct DayView: View {
                                                     calendarEvents: dayEvents,
                                                     profile: profile)
     forecast = summary.hourlyWaveform
-    showHeatMap = summary.coverageRatio >= 0.3 && currentDate <= startOfToday
+    showHeatMap = currentDate <= startOfToday &&
+                 (summary.coverageRatio >= 0.3 || calendar.isDateInToday(currentDate))
     if showHeatMap {
       overallScore = summary.overallEnergyScore
     } else {


### PR DESCRIPTION
## Summary
- show heat map on current day even when coverage is low so forecast appears
- brighten week-view energy gradient and always show today's forecast
- add orange time indicator line to week view

## Testing
- `swiftc -parse EnFlow/Views/Components/WeekCalendarView.swift`
- `swiftc -parse EnFlow/Views/Components/DayView.swift`
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68645b41c270832f835880d14a795c51