### PR TITLE
Fix DayView energy data not loading

### DIFF
--- a/EnFlow/Views/CalendarRootView.swift
+++ b/EnFlow/Views/CalendarRootView.swift
@@ -64,7 +64,8 @@ struct CalendarRootView: View {
             // Dynamic View Injection
             switch mode {
             case .day:
-                DayView(date: Date())
+                // Use startOfDay to ensure DayView loads energy correctly
+                DayView(date: Calendar.current.startOfDay(for: Date()))
                     .transition(.opacity)
             case .week:
                 WeekCalendarView()


### PR DESCRIPTION
## Summary
- ensure DayView defaults to midnight when opened directly from CalendarRootView

## Testing
- `xcodebuild -list -project EnFlow.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68645d613750832f99c86135e00a7a78