### PR TITLE
Increase schedule energy ring size

### DIFF
--- a/EnFlow/Views/Components/DayView.swift
+++ b/EnFlow/Views/Components/DayView.swift
@@ -90,7 +90,7 @@ struct DayView: View {
           EnergyRingView(
             score: overallScore,
             summaryDate: currentDate,
-            size: 100
+            size: 150
           )
           VStack(alignment: .center, spacing: 12) {
             labeledMiniRing(title: "Morning", value: parts?.morning)


### PR DESCRIPTION
## Summary
- make energy ring larger in DayView's schedule page

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686467166e34832fb90fabc907bfa4f7