### PR TITLE
Align calendar controls to right

### DIFF
--- a/EnFlow/Views/CalendarRootView.swift
+++ b/EnFlow/Views/CalendarRootView.swift
@@ -18,7 +18,7 @@ struct CalendarRootView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Dropdown Header with centered Insights button + mode menu
+            // Dropdown header with trailing Insights button and mode menu
             HStack(spacing: 12) {
                 Spacer(minLength: 0)
                 Button(action: { showInsights = true }) {
@@ -63,7 +63,6 @@ struct CalendarRootView: View {
                     )
                 }
                 .foregroundColor(.white)
-                Spacer(minLength: 0)
             }
             .padding(.top, 12)
             .padding(.horizontal, 20)


### PR DESCRIPTION
## Summary
- right-align the insights button and mode switcher in `CalendarRootView`

## Testing
- `swift test` *(fails: could not find Package.swift)*
- `xcodebuild -list -project EnFlow.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68646d7cca98832f998d072603c55926