### PR TITLE
Add fallback message when GPT insights unavailable

### DIFF
--- a/EnFlow/AI/PatternInsightGenerator.swift
+++ b/EnFlow/AI/PatternInsightGenerator.swift
@@ -25,6 +25,6 @@ func generateGPTInsight(from pattern: DetectedPattern) async -> String {
         )
         return text.trimmingCharacters(in: .whitespacesAndNewlines)
     } catch {
-        return "Insight not available."
+        return "EnFlow is working on your predictions, stay tuned for updates!..."
     }
 }

--- a/EnFlow/Views/Components/CalendarInsightsPopup.swift
+++ b/EnFlow/Views/Components/CalendarInsightsPopup.swift
@@ -9,6 +9,8 @@ struct CalendarInsightsPopup: View {
 
     /// Loaded insight texts.
     @State private var insights: [String] = []
+    /// Fallback text shown if GPT doesn't return a summary.
+    private let fallbackMessage = "EnFlow is working on your predictions, stay tuned for updates!..."
 
     var body: some View {
         GeometryReader { proxy in
@@ -19,8 +21,18 @@ struct CalendarInsightsPopup: View {
                             .font(.headline)
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(.bottom, 4)
-                        ForEach(insights, id: \.self) { line in
-                            InsightBannerView(text: line)
+                        if insights.isEmpty {
+                            InsightBannerView(
+                                text: fallbackMessage,
+                                icon: "hourglass"
+                            )
+                        } else {
+                            ForEach(insights, id: \.self) { line in
+                                InsightBannerView(
+                                    text: line,
+                                    icon: line == fallbackMessage ? "hourglass" : "lightbulb"
+                                )
+                            }
                         }
                     }
                     .padding()
@@ -55,8 +67,8 @@ struct CalendarInsightsPopup: View {
             }
 
             for await raw in group {
-                let text = raw == "Insight not available." ?
-                    "Insight unavailable for this pattern." : raw
+                let text = raw == fallbackMessage ?
+                    fallbackMessage : raw
                 if seen.insert(text).inserted {
                     insights.append(text)
                 }


### PR DESCRIPTION
## Summary
- display a fallback banner in CalendarInsightsPopup when GPT summaries are missing
- update `generateGPTInsight` to return the new fallback string

## Testing
- `swift test -t EnFlowTests --disable-sandbox` *(fails: Unknown option)*
- `xcodebuild -list -project EnFlow.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686484be737c832f81e3fc8afbf90124