### PR TITLE
Update insights button to circular lightbulb

### DIFF
--- a/EnFlow/Views/CalendarRootView.swift
+++ b/EnFlow/Views/CalendarRootView.swift
@@ -22,13 +22,12 @@ struct CalendarRootView: View {
             HStack(spacing: 12) {
                 Spacer(minLength: 0)
                 Button(action: { showInsights = true }) {
-                    Text("Insights")
-                        .font(.subheadline.weight(.semibold))
+                    Image(systemName: "lightbulb.fill")
+                        .font(.headline)
                         .foregroundColor(.white)
-                        .padding(.horizontal, 14)
-                        .padding(.vertical, 8)
+                        .padding(8)
                         .background(
-                            Capsule().fill(
+                            Circle().fill(
                                 LinearGradient(
                                     colors: [Color.yellow, Color.orange],
                                     startPoint: .leading,


### PR DESCRIPTION
## Summary
- tweak Insights button in CalendarRootView
- show a smaller circular button with a lightbulb icon

## Testing
- `xcodebuild test -scheme EnFlow -project EnFlow.xcodeproj` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68649d7c286c832fb26168b3f4df1802