### PR TITLE
Make energy insights background transparent

### DIFF
--- a/EnFlow/Views/Components/CalendarInsightsPopup.swift
+++ b/EnFlow/Views/Components/CalendarInsightsPopup.swift
@@ -49,7 +49,7 @@ struct CalendarInsightsPopup: View {
             .cornerRadius(20)
             .shadow(radius: 20)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .enflowBackground()
+            .background(Color.clear.ignoresSafeArea())
         }
         .task { await loadInsights() }
     }


### PR DESCRIPTION
## Summary
- adjust `CalendarInsightsPopup` so its sheet background is clear

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864a1a8debc832f8de18457e7cb1b98