### PR TITLE
Improve DayView energy insights

### DIFF
--- a/EnFlow/Views/Components/DayEnergyInsightsView.swift
+++ b/EnFlow/Views/Components/DayEnergyInsightsView.swift
@@ -5,16 +5,27 @@ struct DayEnergyInsightsView: View {
     let forecast: [Double]
     let events: [CalendarEvent]
     let date: Date
-    
+
+    @State private var showEventImpact: Bool
+
     private let calendar = Calendar.current
-    
+
+    init(forecast: [Double], events: [CalendarEvent], date: Date) {
+        self.forecast = forecast
+        self.events = events
+        self.date = date
+        _showEventImpact = State(initialValue: events.count < 3)
+    }
+
     private var peakHour: Int? {
         guard let maxVal = forecast.max() else { return nil }
         return forecast.firstIndex(of: maxVal)
     }
     private var lowHour: Int? {
-        guard let minVal = forecast.min() else { return nil }
-        return forecast.firstIndex(of: minVal)
+        let rangeHours = 7...19
+        let filtered = forecast.enumerated().filter { rangeHours.contains($0.offset) }
+        guard let minPair = filtered.min(by: { $0.element < $1.element }) else { return nil }
+        return minPair.offset
     }
     
     private func hourLabel(_ hr: Int) -> String {
@@ -30,15 +41,38 @@ struct DayEnergyInsightsView: View {
             }
             if let low = lowHour {
                 insightRow(icon: "arrow.down", color: .blue, title: "Low", hour: low, score: Int(forecast[low]*100))
+            } else {
+                Text("No low point during the active day.")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
             }
+
             if !events.isEmpty {
-                VStack(alignment: .leading, spacing: 12) {
-                    ForEach(events) { ev in
-                        EnergyImpactEventRow(event: ev)
+                VStack(alignment: .leading, spacing: 8) {
+                    Button(action: { withAnimation(.easeInOut) { showEventImpact.toggle() } }) {
+                        HStack {
+                            Text("Event Impact")
+                                .font(.headline)
+                            Spacer()
+                            if !showEventImpact {
+                                Text("\(events.count) events today")
+                                    .foregroundColor(.secondary)
+                            }
+                            Image(systemName: "chevron.down")
+                                .rotationEffect(.degrees(showEventImpact ? 0 : -90))
+                        }
+                    }
+
+                    if showEventImpact {
+                        ForEach(events) { ev in
+                            EnergyImpactEventRow(event: ev, forecast: forecast)
+                        }
                     }
                 }
                 .padding(.top, 8)
+                .animation(.easeInOut, value: showEventImpact)
             }
+
             if let feedback = FeedbackStore.shared.feedback(for: date),
                let note = feedback.note, !note.isEmpty {
                 Text(note)
@@ -66,29 +100,76 @@ struct DayEnergyInsightsView: View {
 
 private struct EnergyImpactEventRow: View {
     let event: CalendarEvent
+    let forecast: [Double]
+
     private let formatter: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "h:mm a"
         return f
     }()
-    
-    private var tagColor: Color {
-        guard let delta = event.energyDelta else { return Color.green.opacity(0.3) }
-        if delta > 0.05 { return .yellow }
-        if delta < -0.05 { return .blue }
-        return Color.green.opacity(0.3)
+
+    private let calendar = Calendar.current
+
+    private func energy(at date: Date) -> Double? {
+        let hr = calendar.component(.hour, from: date)
+        let minute = calendar.component(.minute, from: date)
+        guard forecast.indices.contains(hr) else { return nil }
+        let base = forecast[hr]
+        let next = forecast.indices.contains(hr + 1) ? forecast[hr + 1] : base
+        return base + (next - base) * Double(minute) / 60.0
     }
-    
-    private var tagLabel: String? {
-        guard let delta = event.energyDelta else { return nil }
-        let pct = Int(delta * 100)
-        if delta > 0 { return "+\(pct)% boost" }
-        if delta < 0 { return "\(pct)% drop" }
-        return nil
+
+    private enum ImpactType {
+        case boost(Double)
+        case drain(Double)
+        case neutral(Double)
+        case insufficient
+
+        var color: Color {
+            switch self {
+            case .boost: return .green
+            case .drain: return .red
+            case .neutral: return .gray
+            case .insufficient: return .gray
+            }
+        }
+
+        var icon: String {
+            switch self {
+            case .boost: return "bolt.arrow.up"
+            case .drain: return "battery.25"
+            case .neutral: return "equal.circle"
+            case .insufficient: return "questionmark"
+            }
+        }
+
+        var label: String {
+            switch self {
+            case .boost(let v): return String(format: "+%.0f%%", v)
+            case .drain(let v): return String(format: "%.0f%%", v)
+            case .neutral(let v): return String(format: "%.0f%%", v)
+            case .insufficient: return "Insufficient data"
+            }
+        }
     }
-    
+
+    private var impact: ImpactType {
+        guard let before = energy(at: event.startTime.addingTimeInterval(-1800)),
+              let after = energy(at: event.endTime.addingTimeInterval(1800)) else {
+            return .insufficient
+        }
+        let change = (after - before) * 100
+        if change >= 5 { return .boost(change) }
+        if change <= -5 { return .drain(change) }
+        return .neutral(change)
+    }
+
     var body: some View {
-        HStack(alignment: .center) {
+        HStack(alignment: .center, spacing: 12) {
+            Image(systemName: impact.icon)
+                .foregroundColor(impact.color)
+                .frame(width: 20)
+
             VStack(alignment: .leading, spacing: 2) {
                 Text(event.eventTitle)
                     .font(.subheadline.bold())
@@ -97,19 +178,18 @@ private struct EnergyImpactEventRow: View {
                     .foregroundColor(.secondary)
             }
             Spacer()
-            if let tag = tagLabel {
-                Text(tag)
-                    .font(.caption2.bold())
-                    .padding(.vertical, 4)
-                    .padding(.horizontal, 8)
-                    .background(tagColor)
-                    .clipShape(Capsule())
-                    .foregroundColor(.black)
-            }
+            Text(impact.label)
+                .font(.caption2.bold())
+                .padding(.vertical, 4)
+                .padding(.horizontal, 8)
+                .background(impact.color.opacity(0.2))
+                .clipShape(Capsule())
         }
         .padding(8)
+        .frame(minHeight: 60)
         .background(.regularMaterial)
         .clipShape(RoundedRectangle(cornerRadius: 12))
+        .shadow(color: .black.opacity(0.1), radius: 2, x: 0, y: 1)
     }
 }
 

--- a/EnFlow/Views/Components/DayView.swift
+++ b/EnFlow/Views/Components/DayView.swift
@@ -129,7 +129,6 @@ struct DayView: View {
       }
       .padding()
       .padding(.bottom, 30)
-      .padding(.top, 80)
 
     }
   }


### PR DESCRIPTION
## Summary
- add auto-expanding "Event Impact" section with toggle
- compute energy delta around each event and classify boost/drain/neutral
- handle missing data when no forecast is available
- constrain low-energy search to daylight hours
- remove excess top padding on Energy Insights page

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6864a5cb6fdc832f8cfb6662c29ccbc5