### PR TITLE
Fix historical energy graph

### DIFF
--- a/EnFlow/Views/Components/DayEnergyInsightsView.swift
+++ b/EnFlow/Views/Components/DayEnergyInsightsView.swift
@@ -35,12 +35,17 @@ struct DayEnergyInsightsView: View {
     }
     
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            if let peak = peakHour {
-                insightRow(icon: "arrow.up", color: .yellow, title: "Peak", hour: peak, score: Int(forecast[peak]*100))
-            }
-            if let low = lowHour {
-                insightRow(icon: "arrow.down", color: .blue, title: "Low", hour: low, score: Int(forecast[low]*100))
+        if forecast.isEmpty {
+            Text("No energy data available for this day.")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+        } else {
+            VStack(alignment: .leading, spacing: 16) {
+                if let peak = peakHour {
+                    insightRow(icon: "arrow.up", color: .yellow, title: "Peak", hour: peak, score: Int(forecast[peak]*100))
+                }
+                if let low = lowHour {
+                    insightRow(icon: "arrow.down", color: .blue, title: "Low", hour: low, score: Int(forecast[low]*100))
             } else {
                 Text("No low point during the active day.")
                     .font(.subheadline)


### PR DESCRIPTION
## Summary
- compute past-day energy from stored Health data
- show a no-data message when historical data is missing
- allow insights view and graph to handle empty forecasts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864d26b12e8832fbe03b7d392c3e49e