### PR TITLE
Use historical forecast for past days

### DIFF
--- a/EnFlow/Views/Components/DayView.swift
+++ b/EnFlow/Views/Components/DayView.swift
@@ -2,6 +2,7 @@
 //  EnFlow — Updated Day Calendar with optional back button
 
 import SwiftUI
+import EnergyForecastModel
 
 struct DayView: View {
   // ───────── Inputs ─────────────────────────────────────────
@@ -381,16 +382,27 @@ struct DayView: View {
                                                      healthEvents: healthList,
                                                      calendarEvents: dayEvents,
                                                      profile: profile)
+
+      // full historical forecast
+      let hist = EnergyForecastModel.shared.forecast(
+        for: currentDate,
+        health: healthList,
+        events: dayEvents,
+        profile: profile
+      )
+      if let histValues = hist?.values {
+        forecast = histValues
+      } else if summary.coverageRatio < 0.3 {
+        forecast = []
+      } else {
+        forecast = summary.hourlyWaveform
+      }
     } else {
+      // today/future: unchanged
       summary = UnifiedEnergyModel.shared.summary(for: currentDate,
                                                   healthEvents: healthList,
                                                   calendarEvents: dayEvents,
                                                   profile: profile)
-    }
-
-    if summary.coverageRatio < 0.3 && currentDate < startOfToday {
-      forecast = []
-    } else {
       forecast = summary.hourlyWaveform
     }
     showHeatMap = currentDate <= startOfToday &&


### PR DESCRIPTION
## Summary
- import EnergyForecastModel in DayView
- generate historical forecasts from `EnergyForecastModel` when viewing past days

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6864de9d28a4832fa80c9772de72b373