### PR TITLE
Fix historical forecast call

### DIFF
--- a/EnFlow/Views/Components/DayView.swift
+++ b/EnFlow/Views/Components/DayView.swift
@@ -2,7 +2,6 @@
 //  EnFlow — Updated Day Calendar with optional back button
 
 import SwiftUI
-import EnergyForecastModel
 
 struct DayView: View {
   // ───────── Inputs ─────────────────────────────────────────
@@ -394,13 +393,14 @@ struct DayView: View {
 
     if currentDate < startOfToday {
       // full historical forecast only
-      let hist = EnergyForecastModel.shared.forecast(
+      let model = EnergyForecastModel()
+      let hist = model.forecast(
         for: currentDate,
         health: healthList,
         events: dayEvents,
         profile: profile
       )
-      forecast = hist?.values ?? []
+      forecast = hist.values
     } else {
       // today/future unchanged
       forecast = summary.hourlyWaveform


### PR DESCRIPTION
## Summary
- remove erroneous EnergyForecastModel import
- instantiate EnergyForecastModel for historical forecasts

## Testing
- `xcodebuild -scheme EnFlow -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 15 Pro' -skipMacroValidation test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864e6b98a2c832f946dc80af0a26a59