### PR TITLE
Implement shimmer taper

### DIFF
--- a/EnFlow/Views/Components/EnergyRingView.swift
+++ b/EnFlow/Views/Components/EnergyRingView.swift
@@ -147,6 +147,10 @@ struct EnergyRingView: View {
                                         .trim(from: 0, to: CGFloat(ringProgress))
                                         .stroke(style: StrokeStyle(lineWidth: 20, lineCap: .round))
                                         .rotationEffect(.degrees(-90))
+                                        // Feather the mask edges so the shimmer
+                                        // fades smoothly as it travels across
+                                        // the ring without hard cutoffs.
+                                        .blur(radius: 3)
                                 )
                             )
                     }


### PR DESCRIPTION
## Summary
- feather edges of shimmer mask in `EnergyRingView` to soften highlight as it passes around the ring

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68658f5d1b00832f99877254bfbb0724