### PR TITLE
Fix overlay in Settings preferences

### DIFF
--- a/EnFlow/Views/OnboardingAndSettingsView.swift
+++ b/EnFlow/Views/OnboardingAndSettingsView.swift
@@ -114,24 +114,24 @@ struct OnboardingAndSettingsView: View {
 
     @ViewBuilder
     private var preferencesSection: some View {
-        Section(header: Text("App Preferences")) {
-            Toggle("Enable Notifications", isOn: .constant(false))
-            Picker("GPT Tone", selection: $gptTone) {
-                Text("Wellness").tag("wellness")
-                Text("Scientific").tag("scientific")
-                Text("Friendly").tag("friendly")
+        ZStack {
+            Section(header: Text("App Preferences")) {
+                Toggle("Enable Notifications", isOn: .constant(false))
+                Picker("GPT Tone", selection: $gptTone) {
+                    Text("Wellness").tag("wellness")
+                    Text("Scientific").tag("scientific")
+                    Text("Friendly").tag("friendly")
+                }
+                .pickerStyle(.segmented)
             }
-            .pickerStyle(.segmented)
+            .disabled(true)
+
+            Color.black.opacity(0.6)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            Text("Coming Soon")
+                .font(.largeTitle.bold())
+                .foregroundColor(.white)
         }
-        .disabled(true)
-        .overlay(
-            ZStack {
-                Color.black.opacity(0.6)
-                Text("Coming Soon")
-                    .font(.headline)
-                    .foregroundColor(.white)
-            }
-        )
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- keep the Preferences section header visible
- add a single large "Coming Soon" overlay for the preferences section

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68659019cdc0832f98e7a3c44a91c324