### PR TITLE
Add clear option for chronotype

### DIFF
--- a/EnFlow/AI/OpenAIManager.swift
+++ b/EnFlow/AI/OpenAIManager.swift
@@ -59,7 +59,9 @@ final class OpenAIManager {
         var parts: [String] = []
         parts.append("wake \(fmt.string(from: profile.typicalWakeTime))")
         parts.append("sleep \(fmt.string(from: profile.typicalSleepTime))")
-        parts.append("chronotype \(profile.chronotype.rawValue)")
+        if let ct = profile.chronotype {
+            parts.append("chronotype \(ct.rawValue)")
+        }
         parts.append("caffeine \(profile.caffeineMgPerDay)mg M:\(profile.caffeineMorning) A:\(profile.caffeineAfternoon) E:\(profile.caffeineEvening)")
         parts.append("exercise \(profile.exerciseFrequency)/wk")
         if let notes = profile.notes, !notes.isEmpty { parts.append("notes: \(notes)") }

--- a/EnFlow/Data/EnergySummaryEngine.swift
+++ b/EnFlow/Data/EnergySummaryEngine.swift
@@ -252,10 +252,12 @@ final class EnergySummaryEngine: ObservableObject {
         if !p.mealsRegular { bias -= 2 }
         if p.exerciseFrequency >= 5 { bias += 3 }
         if p.exerciseFrequency <= 1 { bias -= 3 }
-        switch p.chronotype {
-        case .morning: bias += 2
-        case .evening: bias -= 2
-        default: break
+        if let ct = p.chronotype {
+            switch ct {
+            case .morning: bias += 2
+            case .evening: bias -= 2
+            default: break
+            }
         }
         return min(max(0, shifted + bias), 100)
     }

--- a/EnFlow/Models/EnergyForecastModel.swift
+++ b/EnFlow/Models/EnergyForecastModel.swift
@@ -242,10 +242,12 @@ final class EnergyForecastModel: ObservableObject {
     guard let p = profile else { return circadianBoost }
     let wake = calendar.component(.hour, from: p.typicalWakeTime)
     var shift = wake - 7
-    switch p.chronotype {
-    case .morning: shift -= 1
-    case .evening: shift += 1
-    default: break
+    if let ct = p.chronotype {
+      switch ct {
+      case .morning: shift -= 1
+      case .evening: shift += 1
+      default: break
+      }
     }
     let n = circadianBoost.count
     let offset = ((shift % n) + n) % n

--- a/EnFlow/Models/UserProfile.swift
+++ b/EnFlow/Models/UserProfile.swift
@@ -18,7 +18,7 @@ struct UserProfile: Codable, Equatable {
     var usesSleepAid: Bool
     var screensBeforeBed: Bool
     var mealsRegular: Bool
-    var chronotype: Chronotype
+    var chronotype: Chronotype?
     var lastUpdated: Date
     var notes: String?
 }
@@ -39,7 +39,7 @@ extension UserProfile {
             usesSleepAid: false,
             screensBeforeBed: true,
             mealsRegular: true,
-            chronotype: .Afternoon,
+            chronotype: nil,
             lastUpdated: Date(),
             notes: nil
         )
@@ -48,8 +48,9 @@ extension UserProfile {
     func debugSummary() -> String {
         let fmt = DateFormatter()
         fmt.dateFormat = "h:mm a"
+        let chrono = chronotype?.rawValue ?? "N/A"
         return "Caffeine: \(caffeineMgPerDay)mg/day (M:\(caffeineMorning), A:\(caffeineAfternoon), E:\(caffeineEvening)). " +
         "Wake \(fmt.string(from: typicalWakeTime)), Sleep \(fmt.string(from: typicalSleepTime)), " +
-        "Exercise \(exerciseFrequency)x/week, Chronotype \(chronotype.rawValue)."
+        "Exercise \(exerciseFrequency)x/week, Chronotype \(chrono)."
     }
 }

--- a/EnFlow/Views/UserProfileQuizView.swift
+++ b/EnFlow/Views/UserProfileQuizView.swift
@@ -15,7 +15,7 @@ struct UserProfileQuizView: View {
                     Toggle("Regular Meals", isOn: $profile.mealsRegular)
                     Picker("Most Energy [Self Report]", selection: $profile.chronotype) {
                         ForEach(UserProfile.Chronotype.allCases) { c in
-                            Text(c.rawValue.capitalized).tag(c)
+                            Text(c.rawValue.capitalized).tag(Optional(c))
                         }
                     }
                 }

--- a/EnFlow/Views/UserProfileSummaryView.swift
+++ b/EnFlow/Views/UserProfileSummaryView.swift
@@ -145,12 +145,20 @@ struct UserProfileSummaryView: View {
                 Spacer()
                 Picker("", selection: $profile.chronotype) {
                     ForEach(UserProfile.Chronotype.allCases) { c in
-                        Text(c.rawValue.capitalized).tag(c)
+                        Text(c.rawValue.capitalized).tag(Optional(c))
                     }
                 }
                 .pickerStyle(.segmented)
                 .onChange(of: profile.chronotype) { _ in save() }
+                Button(action: { profile.chronotype = nil; save() }) {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(.secondary)
+                }
+                .padding(.leading, 4)
             }
+            Text("When do you feel you have the most energy?")
+                .font(.footnote)
+                .foregroundColor(.secondary)
         }
         .cardStyle()
     }
@@ -365,13 +373,14 @@ struct UserProfileSummaryView: View {
 
     private func loadStory() async {
         isLoadingStory = true
+        let chrono = profile.chronotype?.rawValue ?? "unknown"
         let prompt = """
 OUTPUT PLAIN TEXT FORMATTING ONLY. NO MARKDOWN. Generate a friendly but insightful summary of the user's weekly energy profile based on the following input:
-- Chronotype: \(profile.chronotype.rawValue)
+- Chronotype: \(chrono)
 - Wake/Sleep Time: \(time(profile.typicalWakeTime)) - \(time(profile.typicalSleepTime))
 - Exercise frequency: \(profile.exerciseFrequency)
 - Caffeine habits: \(profile.caffeineMgPerDay)mg — morning: \(profile.caffeineMorning), afternoon: \(profile.caffeineAfternoon), evening: \(profile.caffeineEvening)
-- Most energetic time of day (user-reported): \(profile.chronotype.rawValue)
+- Most energetic time of day (user-reported): \(chrono)
 - Weekly forecasted energy scores (morning/afternoon/evening)
 - Weekly calculated energy scores (morning/afternoon/evening)
 - System-generated insights:


### PR DESCRIPTION
## Summary
- let users clear their chronotype choice by tapping an X button
- display a prompt asking "When do you feel you have the most energy?"
- make `chronotype` optional throughout the app

## Testing
- `swift -version`


------
https://chatgpt.com/codex/tasks/task_e_6865a6cb59b8832f927e26078952ff61