### PR TITLE
Add 7‑day averaged energy rings

### DIFF
--- a/EnFlow/Models/EnergyForecastModel.swift
+++ b/EnFlow/Models/EnergyForecastModel.swift
@@ -133,9 +133,9 @@ final class EnergyForecastModel: ObservableObject {
     guard let wave = forecast(for: date, health: health, events: events, profile: profile)?.values else { return nil }
     func avg(_ s: ArraySlice<Double>) -> Double { s.reduce(0, +) / Double(s.count) * 100.0 }
     return EnergyParts(
-      morning: avg(wave[0..<8]),
-      afternoon: avg(wave[8..<16]),
-      evening: avg(wave[16..<24]))
+      morning: avg(wave[6..<12]),
+      afternoon: avg(wave[12..<18]),
+      evening: avg(wave[18..<24]))
   }
 
 

--- a/EnFlow/Views/Components/ThreePartForecastView.swift
+++ b/EnFlow/Views/Components/ThreePartForecastView.swift
@@ -18,19 +18,17 @@ struct ThreePartForecastView: View {
 
   var body: some View {
     HStack(spacing: spacing) {
-      ring(title: "Morning", value: parts?.morning, startHour: 5)
-      ring(title: "Afternoon", value: parts?.afternoon, startHour: 12)
-      ring(title: "Evening", value: parts?.evening, startHour: 17)
+      ring(title: "Morning", value: parts?.morning)
+      ring(title: "Afternoon", value: parts?.afternoon)
+      ring(title: "Evening", value: parts?.evening)
     }
     .frame(maxWidth: .infinity)
     .saturation(desaturate ? 0.6 : 1.0)
   }
 
   @ViewBuilder
-  private func ring(title: String, value: Double?, startHour: Int) -> some View {
-    let currentHour = Calendar.current.component(.hour, from: Date())
-    let isAvailable = currentHour >= startHour
-
+  private func ring(title: String, value: Double?) -> some View {
+    
     VStack(spacing: 6) {
       ZStack {
         Circle()
@@ -42,7 +40,7 @@ struct ThreePartForecastView: View {
           )
           .frame(width: ringSize, height: ringSize)
 
-        if isAvailable, let val = value {
+        if let val = value {
           Circle()
             .trim(from: 0, to: CGFloat(val / 100))
             .stroke(
@@ -72,11 +70,15 @@ struct ThreePartForecastView: View {
         }
       }
 
-      if isAvailable, let val = value {
+      if let val = value {
         Text(status(for: val))
           .font(.caption2)
           .fontWeight(.medium)
           .foregroundColor(ColorPalette.color(for: val))
+      } else {
+        Text("More data needed")
+          .font(.caption2)
+          .foregroundColor(.secondary)
       }
     }
     .frame(width: ringSize, height: ringSize + 24)

--- a/EnFlow/Views/DashboardView.swift
+++ b/EnFlow/Views/DashboardView.swift
@@ -296,9 +296,9 @@ struct DashboardView: View {
     func slices(from wave: [Double]) -> EnergyForecastModel.EnergyParts {
       func avg(_ s: ArraySlice<Double>) -> Double { s.reduce(0, +) / Double(s.count) * 100 }
       return EnergyForecastModel.EnergyParts(
-        morning: avg(wave[0..<8]),
-        afternoon: avg(wave[8..<16]),
-        evening: avg(wave[16..<24])
+        morning: avg(wave[6..<12]),
+        afternoon: avg(wave[12..<18]),
+        evening: avg(wave[18..<24])
       )
     }
     let tParts = slices(from: tSummary.hourlyWaveform)

--- a/EnFlow/Views/UserProfileSummaryView.swift
+++ b/EnFlow/Views/UserProfileSummaryView.swift
@@ -20,6 +20,7 @@ struct UserProfileSummaryView: View {
     // 7-day averages
     @State private var avgScore: Double? = nil
     @State private var avgParts: EnergyForecastModel.EnergyParts? = nil
+    @State private var daysOfData: Int = 0
 
     /// Classification label + icon based on the average score
     private var classification: (label: String, icon: String) {
@@ -192,15 +193,17 @@ struct UserProfileSummaryView: View {
 
     private var energyProfile: some View {
         VStack(alignment: .leading, spacing: 12) {
+            ThreePartForecastView(parts: avgParts)
+
             if let parts = avgParts {
-                ThreePartForecastView(parts: parts)
-                let best = bestWindow(from: parts)
-                Text("Best energy in \(best)")
+                Text("Best energy in \(bestWindow(from: parts))")
                     .font(.caption)
                     .foregroundColor(.secondary)
-            } else {
-                ThreePartForecastView(parts: nil)
             }
+
+            Text("7-day average for each period")
+                .font(.footnote)
+                .foregroundColor(.secondary)
         }
         .cardStyle()
     }
@@ -355,11 +358,14 @@ struct UserProfileSummaryView: View {
             }
         }
         avgScore = scores.isEmpty ? nil : scores.reduce(0, +) / Double(scores.count)
-        if !m.isEmpty {
+        daysOfData = m.count
+        if m.count >= 3 {
             avgParts = EnergyForecastModel.EnergyParts(
-                morning: m.reduce(0, +)/Double(m.count),
-                afternoon: a.reduce(0, +)/Double(a.count),
-                evening: e.reduce(0, +)/Double(e.count))
+                morning: m.reduce(0, +) / Double(m.count),
+                afternoon: a.reduce(0, +) / Double(a.count),
+                evening: e.reduce(0, +) / Double(e.count))
+        } else {
+            avgParts = nil
         }
     }
 


### PR DESCRIPTION
## Summary
- base `EnergyForecastModel.threePartEnergy` on 6h blocks
- display averages in Dashboard and User Profile
- remove time gating from `ThreePartForecastView`
- show `More data needed` when averages unavailable
- update profile card subtitle

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865a878394c832f8507e516e28abe18