### PR TITLE
Enable clearing peak energy

### DIFF
--- a/EnFlow/Models/UserProfile.swift
+++ b/EnFlow/Models/UserProfile.swift
@@ -2,10 +2,15 @@ import Foundation
 
 struct UserProfile: Codable, Equatable {
     enum Chronotype: String, CaseIterable, Identifiable, Codable {
+        case none
         case morning
         case Afternoon
         case evening
         var id: String { rawValue }
+
+        /// Options presented to the user. Excludes the `none` case used when
+        /// the chronotype is cleared.
+        static var selectableCases: [Chronotype] { [.morning, .Afternoon, .evening] }
     }
 
     var caffeineMgPerDay: Int

--- a/EnFlow/Views/UserProfileQuizView.swift
+++ b/EnFlow/Views/UserProfileQuizView.swift
@@ -13,11 +13,22 @@ struct UserProfileQuizView: View {
                     Toggle("Use Sleep Aid", isOn: $profile.usesSleepAid)
                     Toggle("Screens Before Bed", isOn: $profile.screensBeforeBed)
                     Toggle("Regular Meals", isOn: $profile.mealsRegular)
-                    Picker("Most Energy [Self Report]", selection: $profile.chronotype) {
-                        ForEach(UserProfile.Chronotype.allCases) { c in
-                            Text(c.rawValue.capitalized).tag(c)
+                    HStack {
+                        Picker("Most Energy [Self Report]", selection: $profile.chronotype) {
+                            ForEach(UserProfile.Chronotype.selectableCases) { c in
+                                Text(c.rawValue.capitalized).tag(c)
+                            }
+                        }
+                        Button {
+                            profile.chronotype = .none
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundColor(.secondary)
                         }
                     }
+                    Text("When do you feel you have the most energy?")
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
                 }
 
                 Section("Caffeine") {

--- a/EnFlow/Views/UserProfileSummaryView.swift
+++ b/EnFlow/Views/UserProfileSummaryView.swift
@@ -144,13 +144,23 @@ struct UserProfileSummaryView: View {
                     .font(.subheadline.weight(.medium))
                 Spacer()
                 Picker("", selection: $profile.chronotype) {
-                    ForEach(UserProfile.Chronotype.allCases) { c in
+                    ForEach(UserProfile.Chronotype.selectableCases) { c in
                         Text(c.rawValue.capitalized).tag(c)
                     }
                 }
                 .pickerStyle(.segmented)
                 .onChange(of: profile.chronotype) { _ in save() }
+                Button {
+                    profile.chronotype = .none
+                    save()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(.secondary)
+                }
             }
+            Text("When do you feel you have the most energy?")
+                .font(.footnote)
+                .foregroundColor(.secondary)
         }
         .cardStyle()
     }


### PR DESCRIPTION
## Summary
- allow chronotype to be cleared by adding a `none` case
- let users clear peak energy in the profile quiz and summary
- show hint text for peak energy

## Testing
- `swift test -c release` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6865aa2fa2c4832f966b4226acd7b366