### PR TITLE
Fix Sol notes UI

### DIFF
--- a/EnFlow/Views/UserProfileSummaryView.swift
+++ b/EnFlow/Views/UserProfileSummaryView.swift
@@ -262,7 +262,7 @@ struct UserProfileSummaryView: View {
     }
 
     private var solNotesSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(spacing: 8) {
             NavigationLink(destination: MeetSolView()) {
                 Label("Sol", systemImage: "sun.max.fill")
                     .font(.body.bold())
@@ -289,6 +289,8 @@ struct UserProfileSummaryView: View {
                 set: { profile.notes = $0; save() }
             ))
             .frame(minHeight: 80)
+            .scrollContentBackground(.hidden)
+            .background(Color.clear)
             .overlay(
                 RoundedRectangle(cornerRadius: 8)
                     .stroke(Color.secondary.opacity(0.3))
@@ -297,7 +299,8 @@ struct UserProfileSummaryView: View {
                 .font(.footnote)
                 .foregroundColor(.secondary)
         }
-        .cardStyle()
+        .frame(maxWidth: .infinity)
+        .cardStyle(tint: 100)
     }
 
     // MARK: – Helpers


### PR DESCRIPTION
## Summary
- style `solNotesSection` with yellow card tint
- center the Sol button in the section
- make the text editor transparent

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6865aa880824832f958a1c6c6c8460ed