### PR TITLE
Update tomorrow forecast styling

### DIFF
--- a/EnFlow/Views/Components/DailyEnergyForecastView.swift
+++ b/EnFlow/Views/Components/DailyEnergyForecastView.swift
@@ -8,6 +8,8 @@ struct DailyEnergyForecastView: View {
     let startHour: Int
     /// Hour to highlight with a pulsing dot. Nil to disable.
     let highlightHour: Int?
+    /// Render the line with a dotted stroke for forecast styling.
+    var dotted: Bool = false
     
     @State private var pulse = false
     @State private var activeIndex: Int? = nil
@@ -16,11 +18,12 @@ struct DailyEnergyForecastView: View {
     @State private var graphWidth: CGFloat = 0
     
     private let calendar = Calendar.current
-    
-    init(values: [Double], startHour: Int = 7, highlightHour: Int? = nil) {
+
+    init(values: [Double], startHour: Int = 7, highlightHour: Int? = nil, dotted: Bool = false) {
         self.values = values
         self.startHour = startHour
         self.highlightHour = highlightHour
+        self.dotted = dotted
     }
     
     var body: some View {
@@ -37,13 +40,14 @@ struct DailyEnergyForecastView: View {
                     return CGPoint(x: x, y: y)
                 }
                 let path = smoothPath(points)
-                let stroke = StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round)
+                let dash: [CGFloat] = dotted ? [2, 3] : []
+                let stroke = StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round, dash: dash)
                 
                 ColorPalette.verticalEnergyGradient
                     .mask(path.stroke(style: stroke))
                     .overlay(
                         ColorPalette.verticalEnergyGradient
-                            .mask(path.stroke(style: StrokeStyle(lineWidth: 6, lineCap: .round, lineJoin: .round)))
+                    .mask(path.stroke(style: StrokeStyle(lineWidth: 6, lineCap: .round, lineJoin: .round, dash: dash)))
                             .blur(radius: 3)
                             .opacity(0.7)
                     )

--- a/EnFlow/Views/Components/DayView.swift
+++ b/EnFlow/Views/Components/DayView.swift
@@ -24,6 +24,10 @@ struct DayView: View {
   private let rowHeight: CGFloat = 32
   private let timer = Timer.publish(every: 60, on: .main, in: .common).autoconnect()
   private var isToday: Bool { calendar.isDateInToday(currentDate) }
+  private var isTomorrow: Bool {
+    guard let tomorrow = calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: Date())) else { return false }
+    return calendar.isDate(currentDate, inSameDayAs: tomorrow)
+  }
 
   // ───────── Init ───────────────────────────────────────────
   init(date: Date, showBackButton: Bool = false) {
@@ -129,7 +133,8 @@ struct DayView: View {
           DailyEnergyForecastView(
             values: forecast,
             startHour: 0,
-            highlightHour: isToday ? calendar.component(.hour, from: now) : nil
+            highlightHour: isToday ? calendar.component(.hour, from: now) : nil,
+            dotted: isTomorrow
           )
             .frame(height: 220)
         }


### PR DESCRIPTION
## Summary
- render 24‑hour forecast line as dotted when viewing tomorrow in `DayView`
- support optional dotted style in `DailyEnergyForecastView`

## Testing
- `swift test` *(fails: no Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6865d307f870832f956c3e968c0b1f32