### PR TITLE
Use eligibility for energy display

### DIFF
--- a/EnFlow/Views/Components/DayView.swift
+++ b/EnFlow/Views/Components/DayView.swift
@@ -400,7 +400,6 @@ struct DayView: View {
     )
 
     if currentDate < startOfToday {
-      // full historical forecast only
       let model = EnergyForecastModel()
       let hist = model.forecast(
         for: currentDate,
@@ -408,13 +407,17 @@ struct DayView: View {
         events: dayEvents,
         profile: profile
       )
-        forecast = hist!.values
+      forecast = hist?.values ?? []
     } else {
-      // today/future unchanged
       forecast = summary.hourlyWaveform
     }
+
+    if summary.warning == "Insufficient health data" {
+      forecast = []
+    }
+
     showHeatMap = currentDate <= startOfToday &&
-                 (summary.coverageRatio >= 0.3 || calendar.isDateInToday(currentDate))
+                 summary.warning != "Insufficient health data"
     if showHeatMap {
       overallScore = summary.overallEnergyScore
     } else {

--- a/EnFlow/Views/Components/MonthCalendarView.swift
+++ b/EnFlow/Views/Components/MonthCalendarView.swift
@@ -246,7 +246,7 @@ struct MonthCalendarView: View {
                                                            healthEvents: dayHealth,
                                                            calendarEvents: dayEvents,
                                                            profile: profile)
-            if summary.coverageRatio >= 0.3 {
+            if summary.warning != "Insufficient health data" {
                 results[date] = summary.overallEnergyScore
             }
         }

--- a/EnFlow/Views/Components/WeekCalendarView.swift
+++ b/EnFlow/Views/Components/WeekCalendarView.swift
@@ -293,10 +293,7 @@ struct WeekCalendarView: View {
                                                                   healthEvents: dayHealth,
                                                                   calendarEvents: dayEvents,
                                                                   profile: profile)
-                    if calendar.isDateInToday(day) {
-                        matrix[d] = Array(summary.hourlyWaveform[4...23])
-                        scores[d] = summary.overallEnergyScore
-                    } else if summary.coverageRatio < 0.3 {
+                    if summary.warning == "Insufficient health data" {
                         matrix[d] = Array(repeating: nil, count: hours.count)
                         scores[d] = nil
                     } else {

--- a/EnFlow/Views/DashboardView.swift
+++ b/EnFlow/Views/DashboardView.swift
@@ -141,7 +141,7 @@ struct DashboardView: View {
         }
 
         // — Daily 7 AM‒7 PM line graph —
-        if let wave = todaySummary?.hourlyWaveform {
+        if let wave = todaySummary?.hourlyWaveform, !missingTodayData {
           let slice = Array(wave[7...19])
           VStack(alignment: .leading, spacing: 8) {
             Text("Daily Energy Forecast")
@@ -206,7 +206,7 @@ struct DashboardView: View {
         .help("Forecast accuracy lower than today’s")
         .frame(maxWidth: .infinity)
 
-        if let wave = tomorrowSummary?.hourlyWaveform {
+        if let wave = tomorrowSummary?.hourlyWaveform, !missingTomorrowData {
           VStack(alignment: .leading, spacing: 8) {
             Text("24-Hour Energy Forecast")
               .font(.headline)
@@ -288,9 +288,8 @@ struct DashboardView: View {
         events: eventsTomorrow,
         profile: profile)?.confidenceScore ?? 0
 
-    let todayHealth = healthList.first { cal.isDate($0.date, inSameDayAs: today) }
-    let noToday = !(todayHealth?.hasSamples ?? false)
-    let noTomorrow = forecastConf == 0
+    let noToday = tSummary.warning == "Insufficient health data"
+    let noTomorrow = tmSummary.warning == "Insufficient health data"
 
     // 3-part slices
     func slices(from wave: [Double]) -> EnergyForecastModel.EnergyParts {

--- a/EnFlow/Views/TrendsView.swift
+++ b/EnFlow/Views/TrendsView.swift
@@ -243,6 +243,9 @@ struct TrendsView: View {
 
             let profile = UserProfileStore.load()
             let summary = UnifiedEnergyModel.shared.summary(for: day, healthEvents: h, calendarEvents: ev, profile: profile)
+            if summary.warning == "Insufficient health data" {
+                continue
+            }
             actual.append(summary)
 
             var fWave = ForecastCache.shared.forecast(for: day)?.values

--- a/EnFlow/Views/UserProfileSummaryView.swift
+++ b/EnFlow/Views/UserProfileSummaryView.swift
@@ -375,13 +375,15 @@ struct UserProfileSummaryView: View {
         for i in 0..<7 {
             guard let day = cal.date(byAdding: .day, value: -i, to: cal.startOfDay(for: Date())) else { continue }
             let summary = UnifiedEnergyModel.shared.summary(for: day, healthEvents: health, calendarEvents: events, profile: profile)
-            scores.append(summary.overallEnergyScore)
-            if let part = model.threePartEnergy(for: day, health: health, events: events, profile: profile) {
-                m.append(part.morning); a.append(part.afternoon); e.append(part.evening)
+            if summary.warning != "Insufficient health data" {
+                scores.append(summary.overallEnergyScore)
+                if let part = model.threePartEnergy(for: day, health: health, events: events, profile: profile) {
+                    m.append(part.morning); a.append(part.afternoon); e.append(part.evening)
+                }
             }
         }
         avgScore = scores.isEmpty ? nil : scores.reduce(0, +) / Double(scores.count)
-        daysOfData = m.count
+        daysOfData = scores.count
         if m.count >= 3 {
             avgParts = EnergyForecastModel.EnergyParts(
                 morning: m.reduce(0, +) / Double(m.count),


### PR DESCRIPTION
## Summary
- check for "Insufficient health data" before showing energy
- propagate eligibility through Dashboard, Day view and calendars
- ignore ineligible days in user profile averages and trends data

## Testing
- `swift --version`
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68780d53a510832fb43e3f50f6a79ca3