### PR TITLE
Revamp priority cards with urgency tags

### DIFF
--- a/EnFlow/Models/SuggestedPrioritiesEngine.swift
+++ b/EnFlow/Models/SuggestedPrioritiesEngine.swift
@@ -42,6 +42,11 @@ enum PriorityTemplate: String, Codable, CaseIterable, Hashable, Identifiable {
     }
 }
 
+enum PriorityUrgencyLevel: String, Codable {
+    case low, moderate, high
+    var label: String { rawValue.capitalized }
+}
+
 struct TemplatePrompt: Identifiable, Hashable, Codable {
     let id       = UUID()
     let template : PriorityTemplate
@@ -53,6 +58,8 @@ struct PriorityResult: Identifiable, Hashable, Codable {
     let template  : PriorityTemplate
     let text      : String              // “Title\nBody”
     var rationale : String   = ""
+    var urgency   : PriorityUrgencyLevel = .moderate
+    var rationaleTags: [String] = []
 
     // Action-state (UI local)
     var isPinned        = false
@@ -68,6 +75,8 @@ struct PriorityResult: Identifiable, Hashable, Codable {
     init(template: PriorityTemplate, text: String) {
         self.template = template
         self.text     = text
+        self.urgency  = .moderate
+        self.rationaleTags = []
     }
 }
 

--- a/EnFlow/Views/Components/RationaleChip.swift
+++ b/EnFlow/Views/Components/RationaleChip.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+/// Capsule tag used to display short rationale labels.
+struct RationaleChip: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(.caption2.weight(.semibold))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(
+                Capsule()
+                    .fill(.ultraThinMaterial)
+            )
+            .overlay(
+                Capsule()
+                    .stroke(Color.white.opacity(0.15))
+            )
+    }
+}
+
+#Preview {
+    RationaleChip(text: "Low HRV")
+        .padding()
+        .background(Color.black)
+}

--- a/EnFlow/Views/Components/SuggestedPrioritiesInfoView.swift
+++ b/EnFlow/Views/Components/SuggestedPrioritiesInfoView.swift
@@ -12,7 +12,7 @@ struct SuggestedPrioritiesInfoView: View {
                         priorityRow(t)
                     }
                     Divider()
-                    Text("Sol combines 3-part energy forecasts with your calendar gaps, sleep quality and HRV trends. A GPT engine ranks templates by fit. Your feedback — pin, snooze or dismiss — tunes future recommendations.")
+                    Text("Sol blends energy forecasts with your schedule, sleep and recovery to surface three quick nudges each day. Cards include an urgency badge and short rationale tags so you know why they matter. Pin, snooze or dismiss to refine future picks.")
                         .font(.body)
                     Button("Update your profile") { showProfileQuiz = true }
                         .buttonStyle(.borderedProminent)


### PR DESCRIPTION
## Summary
- support urgency and rationale tags on PriorityResult model
- add modular subviews and new `RationaleChip` component
- style SuggestedPrioritiesView cards with urgency header, body and tag list
- refresh info text describing urgency badges

## Testing
- `swiftc -typecheck EnFlow/Views/Components/RationaleChip.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68787c8f1508832fa3a500f30c3a3f35