### PR TITLE
Adjust energy graphs to user wake/sleep window

### DIFF
--- a/EnFlow/Views/Components/DailyEnergyForecastView.swift
+++ b/EnFlow/Views/Components/DailyEnergyForecastView.swift
@@ -90,12 +90,14 @@ struct DailyEnergyForecastView: View {
                     }
                 )
                 
-                if let h = highlightHour, h >= startHour, h < startHour + count {
-                    let idx = h - startHour
-                    let pt = points[idx]
-                    Circle()
-                        .fill(Color.white)
-                        .frame(width: 8, height: 8)
+                if var h = highlightHour {
+                    if h < startHour { h += 24 }
+                    if h >= startHour && h < startHour + count {
+                        let idx = h - startHour
+                        let pt = points[idx]
+                        Circle()
+                            .fill(Color.white)
+                            .frame(width: 8, height: 8)
                         .overlay(
                             Circle()
                                 .stroke(Color.white.opacity(0.8), lineWidth: 2)
@@ -112,7 +114,7 @@ struct DailyEnergyForecastView: View {
 
                 ForEach(Array(stride(from: 0, to: count, by: 2)), id: \.self) { idx in
                     let x = width * CGFloat(idx) / CGFloat(max(count - 1, 1))
-                    Text(hourLabel(startHour + idx))
+                    Text(hourLabel((startHour + idx) % 24))
                         .font(.system(size: 8))
                         .foregroundColor(.secondary)
                         .position(x: x, y: height + 10)
@@ -141,7 +143,7 @@ struct DailyEnergyForecastView: View {
                 if let idx = activeIndex {
                     let point = points[idx]
                     let score = Int(clamped[idx] * 100)
-                    let label = hourLabel(startHour + idx)
+                    let label = hourLabel((startHour + idx) % 24)
 
                     Path { p in
                         p.move(to: point)

--- a/EnFlow/Views/DashboardView.swift
+++ b/EnFlow/Views/DashboardView.swift
@@ -141,15 +141,21 @@ struct DashboardView: View {
 
         }
 
-        // — Daily 7 AM‒7 PM line graph —
+        // — Daily line graph —
         if let wave = todaySummary?.hourlyWaveform, !missingTodayData {
-          let slice = Array(wave[7...19])
+          let profile = UserProfileStore.load()
+          let range = visibleRange(for: profile, default: 7..<19)
+          let slice = energySlice(wave, range: range)
+          let startHour = range.lowerBound % 24
+          var highlight = Calendar.current.component(.hour, from: Date())
+          if range.upperBound > 24 && highlight < startHour { highlight += 24 }
           VStack(alignment: .leading, spacing: 8) {
             Text("Daily Energy Forecast")
                   .font(.headline)
             DailyEnergyForecastView(
               values: slice,
-              highlightHour: Calendar.current.component(.hour, from: Date())
+              startHour: startHour,
+              highlightHour: highlight
             )
           }
         }
@@ -206,11 +212,17 @@ struct DashboardView: View {
         .frame(maxWidth: .infinity)
 
         if let wave = tomorrowSummary?.hourlyWaveform, !missingTomorrowData {
+          let profile = UserProfileStore.load()
+          let range = visibleRange(for: profile, default: 0..<24)
+          let slice = energySlice(wave, range: range)
+          let startHour = range.lowerBound % 24
           VStack(alignment: .leading, spacing: 8) {
             Text("24-Hour Energy Forecast")
               .font(.headline)
               .saturation(0.7)
-            DailyEnergyForecastView(values: wave, startHour: 0, showWarning: tomorrowForecastWarning)
+            DailyEnergyForecastView(values: slice,
+                                    startHour: startHour,
+                                    showWarning: tomorrowForecastWarning)
               .saturation(0.7)
           }
         }


### PR DESCRIPTION
## Summary
- add `visibleRange` and `energySlice` helpers
- update energy graph view to wrap hours over midnight
- slice dashboard graphs using the user's wake/sleep times
- apply same slicing to tomorrow and calendar day views

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878a395fa1c832f945407ce61a29362