### PR TITLE
Fix energy graph hour labels

### DIFF
--- a/EnFlow/Views/Components/DailyEnergyForecastView.swift
+++ b/EnFlow/Views/Components/DailyEnergyForecastView.swift
@@ -128,8 +128,9 @@ struct DailyEnergyForecastView: View {
                 }
 
 
-                // X-axis hour labels
-                ForEach(Array(stride(from: 0, to: count, by: 2)), id: \.self) { idx in
+                // X-axis hour labels — aim for ≈12 markers maximum
+                let step = max(1, Int(ceil(Double(count) / 12.0)))
+                ForEach(Array(stride(from: 0, to: count, by: step)), id: \.self) { idx in
                     let x = width * CGFloat(idx) / CGFloat(max(count - 1, 1))
                     Text(hourLabel((startHour + idx) % 24))
                         .font(.system(size: 8))


### PR DESCRIPTION
## Summary
- keep x-axis ticks consistent in energy forecast graphs

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878ab059f6c832fa3b2552ecc59afcd