### PR TITLE
Add popover warnings for fallback forecasts

### DIFF
--- a/EnFlow/Utilities/EmbossedWarningButtonStyle.swift
+++ b/EnFlow/Utilities/EmbossedWarningButtonStyle.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+/// Button style for warning icons with an embossed glow.
+struct EmbossedWarningButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .foregroundColor(.yellow)
+            .padding(4)
+            .background(
+                Circle()
+                    .fill(Color.yellow.opacity(0.25))
+                    .shadow(color: .black.opacity(0.4), radius: configuration.isPressed ? 1 : 2, x: 1, y: 1)
+                    .shadow(color: .white.opacity(0.4), radius: configuration.isPressed ? 1 : 2, x: -1, y: -1)
+            )
+            .clipShape(Circle())
+    }
+}
+
+extension ButtonStyle where Self == EmbossedWarningButtonStyle {
+    static var embossedWarning: EmbossedWarningButtonStyle { EmbossedWarningButtonStyle() }
+}

--- a/EnFlow/Utilities/WarningIconButton.swift
+++ b/EnFlow/Utilities/WarningIconButton.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+/// Small warning icon that shows a popover with details when tapped or hovered.
+struct WarningIconButton: View {
+    let message: String
+    @State private var show = false
+
+    var body: some View {
+        Button { show = true } label: {
+            Image(systemName: "exclamationmark.triangle.fill")
+        }
+        .buttonStyle(.embossedWarning)
+        .accessibilityLabel(message)
+        .help(message)
+        .popover(isPresented: $show) {
+            Text(message)
+                .font(.body)
+                .padding()
+                .frame(maxWidth: 240)
+        }
+    }
+}

--- a/EnFlow/Views/Components/EnergyRingView.swift
+++ b/EnFlow/Views/Components/EnergyRingView.swift
@@ -26,6 +26,8 @@ struct EnergyRingView: View {
     var showInfoButton: Bool = true
     /// Show the numeric score label in the center
     var showValueLabel: Bool = true
+    /// Optional warning message for low confidence forecasts
+    var warningMessage: String? = nil
 
     // ───────── Engine + State ──────────────────────────────────────
     @ObservedObject private var engine = EnergySummaryEngine.shared
@@ -240,19 +242,22 @@ struct EnergyRingView: View {
                 .transition(.scale.combined(with: .opacity))
             }
 
-            // — Info button (top-right) —
-            if showInfoButton {
-                VStack {
-                    HStack {
-                        Spacer()
+            // — Info & warning buttons (top-right) —
+            VStack {
+                HStack {
+                    if let msg = warningMessage {
+                        WarningIconButton(message: msg)
+                    }
+                    if showInfoButton {
                         Button { showExplanation = true } label: {
                             Image(systemName: "info.circle")
                                 .font(.headline)
                         }
                         .buttonStyle(.embossedInfo)
                     }
-                    Spacer()
+                    Spacer(minLength: 0)
                 }
+                Spacer()
             }
         }
         .frame(width: size, height: size)

--- a/EnFlow/Views/Components/ThreePartForecastView.swift
+++ b/EnFlow/Views/Components/ThreePartForecastView.swift
@@ -11,8 +11,8 @@ struct ThreePartForecastView: View {
   let parts: EnergyForecastModel.EnergyParts?
   var dashed: Bool = false
   var desaturate: Bool = false
-  /// Display a low-confidence badge
-  var showWarning: Bool = false
+  /// Optional warning message displayed via icon
+  var warningMessage: String? = nil
 
   private let ringSize: CGFloat = 80
   private let lineWidth: CGFloat = 6
@@ -27,16 +27,8 @@ struct ThreePartForecastView: View {
     .frame(maxWidth: .infinity)
     .saturation(desaturate ? 0.6 : 1.0)
     .overlay(alignment: .topTrailing) {
-      if showWarning {
-        HStack(spacing: 4) {
-          Image(systemName: "exclamationmark.triangle.fill")
-          Text("Limited data")
-        }
-        .font(.caption2.bold())
-        .foregroundColor(.yellow)
-        .padding(4)
-        .background(.ultraThinMaterial, in: Capsule())
-        .help("Limited data today — energy estimates may be less accurate.")
+      if let msg = warningMessage {
+        WarningIconButton(message: msg)
       }
     }
   }


### PR DESCRIPTION
## Summary
- add reusable `WarningIconButton` and style
- show warning icons in `DailyEnergyForecastView`
- add optional warning button to `EnergyRingView` and `ThreePartForecastView`
- surface forecast messages in `DashboardView` and `DayView`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878ac0190e8832fb73ae49be442607b