### PR TITLE
Add RADIANT status for perfect energy score

### DIFF
--- a/EnFlow/Views/Components/EnergyRingView.swift
+++ b/EnFlow/Views/Components/EnergyRingView.swift
@@ -54,6 +54,8 @@ struct EnergyRingView: View {
             return "MODERATE"
         case 90..<100:
             return "SUPERCHARGED"
+        case 100:
+            return "RADIANT"
         default:
             return "HIGH"
         }


### PR DESCRIPTION
## Summary
- update EnergyRingView status logic so scores of 100 show **RADIANT**

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878aca20ca0832fbd25ca1c446c8b6e