### PR TITLE
Improve action refresh behavior

### DIFF
--- a/EnFlow/AI/GPTActionGenerator.swift
+++ b/EnFlow/AI/GPTActionGenerator.swift
@@ -21,14 +21,16 @@ func generateActions(
     energy: Double,
     hrv: Double,
     sleep: Double,
-    calendar: [CalendarEvent]
+    calendar: [CalendarEvent],
+    forceRefresh: Bool = false
 ) async throws -> [ActionCard] {
     let prompt = buildPrompt(for: mode, hour: hour, energy: energy, hrv: hrv, sleep: sleep, calendar: calendar)
 
     let responseText = try await OpenAIManager.shared.generateInsight(
         prompt: "You are an expert rhythm and recovery assistant.\n" + prompt,
         maxTokens: 180,
-        temperature: 0.7
+        temperature: 0.7,
+        forceRefresh: forceRefresh
     )
 
     guard responseText.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("[") else {

--- a/EnFlow/Models/ActionsViewModel.swift
+++ b/EnFlow/Models/ActionsViewModel.swift
@@ -33,7 +33,8 @@ final class ActionsViewModel: ObservableObject {
                 energy: energy,
                 hrv: hrv,
                 sleep: sleep,
-                calendar: events
+                calendar: events,
+                forceRefresh: force
             )
         } catch {
             self.cards = []


### PR DESCRIPTION
## Summary
- allow `generateInsight` and underlying `chatCompletion` to bypass the GPT cache
- expose `forceRefresh` option in `generateActions`
- trigger cache bypass from `ActionsViewModel` reload button

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6878b179e854832fb8a46e908b8254d0