### PR TITLE
Add restart experience control

### DIFF
--- a/EnFlow/Energy/Data/CalendarDataPipeline.swift
+++ b/EnFlow/Energy/Data/CalendarDataPipeline.swift
@@ -84,4 +84,8 @@ final class CalendarDataPipeline: ObservableObject {
         let endDay   = cal.date(byAdding: .day, value: 1, to: startDay) ?? startDay
         return await fetchEvents(start: startDay, end: endDay)
     }
+
+    func clearCache() {
+        // No persistent caching yet; placeholder for future use.
+    }
 }

--- a/EnFlow/Energy/Data/HealthDataPipeline.swift
+++ b/EnFlow/Energy/Data/HealthDataPipeline.swift
@@ -213,4 +213,8 @@ final class HealthDataPipeline: ObservableObject {
                                       end: end)
         return Int(count)
     }
+
+    func clearCache() {
+        // No persistent caching implemented; placeholder for future use.
+    }
 }

--- a/EnFlow/Energy/Storage/ForecastCache.swift
+++ b/EnFlow/Energy/Storage/ForecastCache.swift
@@ -100,4 +100,8 @@ final class ForecastCache {
         forecasts.removeAll()
         persist()
     }
+
+    func reset() {
+        clearAllCachedData()
+    }
 }

--- a/EnFlow/Models/UserProfileStore.swift
+++ b/EnFlow/Models/UserProfileStore.swift
@@ -19,4 +19,8 @@ enum UserProfileStore {
             try? data.write(to: fileURL, options: [.atomic])
         }
     }
+
+    static func resetProfile() {
+        save(UserProfile.default)
+    }
 }


### PR DESCRIPTION
## Summary
- allow the user to restart onboarding and clear app data
- add `performFullReset()` helper and use alert in developer section
- provide reset helpers for data stores and pipelines

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6878c3e116a4832fa78ce7f4ea75ebfb