### PR TITLE
Show walkthrough before permissions onboarding

### DIFF
--- a/EnFlow/EnFlowApp.swift
+++ b/EnFlow/EnFlowApp.swift
@@ -9,6 +9,7 @@ import UIKit
 @main
 struct EnFlowApp: App {
     @AppStorage("didCompleteOnboarding") private var onboarded = false
+    @AppStorage("didCompleteWalkthrough") private var walkthroughDone = false
 
 #if os(iOS)
     init() { setupAppearance() }
@@ -19,8 +20,10 @@ struct EnFlowApp: App {
             Group {
                 if onboarded {
                     MainShellView()
-                } else {
+                } else if walkthroughDone {
                     OnboardingAndSettingsView()
+                } else {
+                    OnboardingWalkthroughView()
                 }
             }
             .preferredColorScheme(.dark)

--- a/EnFlow/Settings/OnboardingWalkthroughView.swift
+++ b/EnFlow/Settings/OnboardingWalkthroughView.swift
@@ -15,7 +15,7 @@ import SwiftUI
 
 struct OnboardingWalkthroughView: View {
     /// Controls dismissal when "Start Using EnFlow" is tapped.
-    @AppStorage("didCompleteOnboarding") private var didCompleteOnboarding = false
+    @AppStorage("didCompleteWalkthrough") private var didCompleteWalkthrough = false
 
     var body: some View {
         TabView {
@@ -25,7 +25,7 @@ struct OnboardingWalkthroughView: View {
             PageSync()
             PageExpectations()
             PageMeetSol()
-            PageEarlyTester(didCompleteOnboarding: $didCompleteOnboarding)
+            PageEarlyTester(didCompleteWalkthrough: $didCompleteWalkthrough)
         }
         .tabViewStyle(PageTabViewStyle())
         .ignoresSafeArea()  // full‑bleed backgrounds
@@ -249,7 +249,7 @@ private struct PageMeetSol: View {
 }
 
 private struct PageEarlyTester: View {
-    @Binding var didCompleteOnboarding: Bool
+    @Binding var didCompleteWalkthrough: Bool
     var body: some View {
         ZStack {
             LinearGradient(colors: [Color(#colorLiteral(red:0.05, green:0.08, blue:0.2, alpha:1)), Color(#colorLiteral(red:0.1, green:0.1, blue:0.12, alpha:1))], startPoint: .topLeading, endPoint: .bottomTrailing)
@@ -265,7 +265,7 @@ private struct PageEarlyTester: View {
                     .multilineTextAlignment(.center)
                     .foregroundColor(.white.opacity(0.85))
                     .padding(.horizontal, 32)
-                Button(action: { didCompleteOnboarding = true }) {
+                Button(action: { didCompleteWalkthrough = true }) {
                     Text("Start Using EnFlow")
                         .font(.headline)
                         .padding(.horizontal, 48)


### PR DESCRIPTION
## Summary
- show `OnboardingWalkthroughView` before permissions onboarding
- track walkthrough completion separately via `didCompleteWalkthrough`

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6878c69402b0832faff8799f3378fc18