### PR TITLE
Implement bed-wake shaping in energy waves

### DIFF
--- a/EnFlow/Energy/Calculation/EnergyForecastModel.swift
+++ b/EnFlow/Energy/Calculation/EnergyForecastModel.swift
@@ -125,6 +125,7 @@ final class EnergyForecastModel: ObservableObject {
     }
 
     wave = smooth(wave)
+    shapeBedWake(for: date, profile: profile, into: &wave)
 
     let missing = Set(MetricType.allCases).subtracting(hSample.availableMetrics)
     var confidence = 0.2
@@ -297,4 +298,37 @@ final class EnergyForecastModel: ObservableObject {
     let offset = ((shift % n) + n) % n
     return Array(circadianBoost[offset..<n] + circadianBoost[0..<offset])
   }
+}
+
+private func shapeBedWake(for date: Date,
+                          profile: UserProfile?,
+                          calendar: Calendar = .current,
+                          into wave: inout [Double]) {
+    guard let p = profile else { return }
+    let bedHr  = calendar.component(.hour, from: p.typicalSleepTime)
+    let wakeHr = calendar.component(.hour, from: p.typicalWakeTime)
+
+    // ---- Day-specific random-ish magnitude (8–15 %) ----
+    let seed = calendar.ordinality(of: .day, in: .era, for: date) ?? 0
+    let rand = Double((seed &* 1664525 &+ 1013904223) % 1000) / 1000.0
+    let mag  = 0.08 + rand * 0.07          // 0.08 … 0.15
+
+    // ---- Downtick: last 1-3 h before bed ----
+    let downSpan = max(1, Int(1 + rand * 2))  // 1-3 h
+    for i in 0..<downSpan {
+        let h = (bedHr - 1 - i + 24) % 24
+        let factor = mag * Double(i + 1) / Double(downSpan)
+        wave[h] = max(0, wave[h] - factor)
+    }
+
+    // ---- Uptick: first 1-3 h after wake ----
+    let upSpan = max(1, Int(1 + (1 - rand) * 2))  // 1-3 h (inverse of rand)
+    for i in 0..<upSpan {
+        let h = (wakeHr + i) % 24
+        let factor = mag * 0.6 * Double(upSpan - i) / Double(upSpan)
+        wave[h] = min(1, wave[h] + factor)
+    }
+
+    // ---- Hard floor for end-of-day value ----
+    wave[23] = min(wave[23], 0.50)
 }

--- a/EnFlow/Energy/Calculation/EnergySummaryEngine.swift
+++ b/EnFlow/Energy/Calculation/EnergySummaryEngine.swift
@@ -132,7 +132,7 @@ final class EnergySummaryEngine: ObservableObject {
         let overall = baselineAdjusted(rawOverall, profile: profile)
 
         // 24-h waveform (starts flat, apply event deltas)
-        let wave = hourlyWaveform(base: overall / 100.0, events: cRows)
+        let wave = hourlyWaveform(base: overall / 100.0, events: cRows, start: start, profile: profile)
 
         // Top boosters / drainers
         let boosters = topEvents(from: cRows, positive: true)
@@ -236,7 +236,9 @@ final class EnergySummaryEngine: ObservableObject {
 
     // ───────── Waveform builder ──────────────────────────────────
     private func hourlyWaveform(base: Double,
-                                events: [CalendarEvent]) -> [Double] {
+                                events: [CalendarEvent],
+                                start: Date,
+                                profile: UserProfile?) -> [Double] {
         var wave = circadianBoost.map { max(0, min(1, base + $0)) }
         for ev in events {
             guard let delta = ev.energyDelta else { continue }
@@ -245,6 +247,7 @@ final class EnergySummaryEngine: ObservableObject {
                 wave[hr] = max(0, min(1, wave[hr] + delta))
             }
         }
+        shapeBedWake(for: start, profile: profile, into: &wave)
         return wave
     }
 
@@ -323,4 +326,37 @@ final class EnergySummaryEngine: ObservableObject {
 
         return Array(out.prefix(5))
     }
+}
+
+private func shapeBedWake(for date: Date,
+                          profile: UserProfile?,
+                          calendar: Calendar = .current,
+                          into wave: inout [Double]) {
+    guard let p = profile else { return }
+    let bedHr  = calendar.component(.hour, from: p.typicalSleepTime)
+    let wakeHr = calendar.component(.hour, from: p.typicalWakeTime)
+
+    // ---- Day-specific random-ish magnitude (8–15 %) ----
+    let seed = calendar.ordinality(of: .day, in: .era, for: date) ?? 0
+    let rand = Double((seed &* 1664525 &+ 1013904223) % 1000) / 1000.0
+    let mag  = 0.08 + rand * 0.07          // 0.08 … 0.15
+
+    // ---- Downtick: last 1-3 h before bed ----
+    let downSpan = max(1, Int(1 + rand * 2))  // 1-3 h
+    for i in 0..<downSpan {
+        let h = (bedHr - 1 - i + 24) % 24
+        let factor = mag * Double(i + 1) / Double(downSpan)
+        wave[h] = max(0, wave[h] - factor)
+    }
+
+    // ---- Uptick: first 1-3 h after wake ----
+    let upSpan = max(1, Int(1 + (1 - rand) * 2))  // 1-3 h (inverse of rand)
+    for i in 0..<upSpan {
+        let h = (wakeHr + i) % 24
+        let factor = mag * 0.6 * Double(upSpan - i) / Double(upSpan)
+        wave[h] = min(1, wave[h] + factor)
+    }
+
+    // ---- Hard floor for end-of-day value ----
+    wave[23] = min(wave[23], 0.50)
 }

--- a/EnFlowTests/EnergyForecastModelTests.swift
+++ b/EnFlowTests/EnergyForecastModelTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import EnFlow
+
+final class EnergyForecastModelTests: XCTestCase {
+    func testBedWakeShapingVariability() {
+        let cal = Calendar.current
+        ForecastCache.shared.clearAllCachedData()
+        let model = EnergyForecastModel()
+
+        let startDay = cal.date(from: DateComponents(year: 2025, month: 1, day: 1))!
+        var profile = UserProfile.default
+        profile.typicalWakeTime = cal.date(bySettingHour: 7, minute: 0, second: 0, of: startDay)!
+        profile.typicalSleepTime = cal.date(bySettingHour: 23, minute: 0, second: 0, of: startDay)!
+
+        var health: [HealthEvent] = []
+        for i in 0..<30 {
+            let d = cal.date(byAdding: .day, value: i, to: startDay)!
+            let he = HealthEvent(
+                date: d,
+                hrv: 80,
+                restingHR: 55,
+                heartRate: 60,
+                sleepEfficiency: 90,
+                sleepLatency: 10,
+                deepSleep: 100,
+                remSleep: 90,
+                timeInBed: 450,
+                steps: 8000,
+                calories: 2000,
+                availableMetrics: Set(MetricType.allCases),
+                hasSamples: true
+            )
+            health.append(he)
+        }
+
+        var magnitudes: [Double] = []
+        for i in 0..<30 {
+            let day = cal.date(byAdding: .day, value: i, to: startDay)!
+            guard let forecast = model.forecast(for: day, health: health, events: [], profile: profile) else {
+                XCTFail("No forecast")
+                return
+            }
+            let wave = forecast.values
+            let bedHr = cal.component(.hour, from: profile.typicalSleepTime)
+            let wakeHr = cal.component(.hour, from: profile.typicalWakeTime)
+            XCTAssertLessThanOrEqual(wave[23], 0.50)
+            let preBed1 = (bedHr - 1 + 24) % 24
+            let preBed3 = (bedHr - 3 + 24) % 24
+            XCTAssertLessThan(wave[preBed1], wave[preBed3])
+            XCTAssertGreaterThan(wave[wakeHr], wave[(wakeHr - 1 + 24) % 24])
+            magnitudes.append(wave[preBed3] - wave[preBed1])
+        }
+
+        let mean = magnitudes.reduce(0, +) / Double(magnitudes.count)
+        let variance = magnitudes.reduce(0) { $0 + pow($1 - mean, 2) } / Double(magnitudes.count)
+        let stdDev = sqrt(variance)
+        XCTAssertGreaterThan(stdDev, 0.01)
+    }
+}


### PR DESCRIPTION
## Summary
- adjust EnergyForecastModel to taper energy before bed and boost after wake
- integrate bed-wake shaping into EnergySummaryEngine wave generator
- cap last hourly value at 50%
- add unit test validating shaping variability over 30 days

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68796d5284b8832f8c685eb14ef597c0