### PR TITLE
Update onboarding walkthrough polish

### DIFF
--- a/EnFlow/Views/Components/DailyEnergyForecastView.swift
+++ b/EnFlow/Views/Components/DailyEnergyForecastView.swift
@@ -238,9 +238,8 @@ struct DailyEnergyForecastView: View {
     }
 
     private func hourLabel(_ hour: Int) -> String {
-        var comps = DateComponents(); comps.hour = hour
-        return calendar.date(from: comps)?
-            .formatted(.dateTime.hour(.defaultDigits(amPM: .abbreviated))) ?? "\(hour)h"
+        let hr = (hour % 24 + 24) % 24
+        return "\(hr)h"
     }
 
     private func significantPeaksAndTroughs(threshold: Double = 0.15) -> [Int] {


### PR DESCRIPTION
## Summary
- reorder onboarding pages for final flow
- add animated lightning bolt icon on the welcome screen
- expand energy ring demo states with titles and descriptions
- add footnote disclaimer on the energy ring demo
- remove supercharged bolt overlay and respect Reduce Motion
- display waveform x‑axis as 24‑hour time values

## Testing
- `swiftc -parse EnFlow/Views/OnboardingWalkthroughView.swift`
- `swiftc -parse EnFlow/Views/Components/DailyEnergyForecastView.swift`
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879975bcf10832f8138da106d494161