### PR TITLE
Add white glow for Boost action cards

### DIFF
--- a/EnFlow/Views/Components/ActionsView.swift
+++ b/EnFlow/Views/Components/ActionsView.swift
@@ -141,6 +141,8 @@ struct ActionCardView: View {
         .background(background)
         .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
         .overlay(borderOverlay)
+        .shadow(color: card.category == .boost ? .white.opacity(0.7) : .clear,
+                radius: card.category == .boost ? 4 : 0)
     }
 
     private var background: Color {


### PR DESCRIPTION
## Summary
- emphasize Boost actions with a white glow around each card's border

## Testing
- `xcodebuild test -scheme EnFlow -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68799b5bd29c832fa5073e728f1b376e