### PR TITLE
Switch energy graph to 12‑hour labels

### DIFF
--- a/EnFlow/Views/Components/DailyEnergyForecastView.swift
+++ b/EnFlow/Views/Components/DailyEnergyForecastView.swift
@@ -238,8 +238,12 @@ struct DailyEnergyForecastView: View {
     }
 
     private func hourLabel(_ hour: Int) -> String {
-        let hr = (hour % 24 + 24) % 24
-        return "\(hr)h"
+        var comps = DateComponents()
+        comps.hour = hour
+        return calendar.date(from: comps)?
+            .formatted(
+                .dateTime.hour(.defaultDigits(amPM: .abbreviated))
+            ) ?? "\(hour)h"
     }
 
     private func significantPeaksAndTroughs(threshold: Double = 0.15) -> [Int] {


### PR DESCRIPTION
## Summary
- show AM/PM times on energy waveform x-axis

## Testing
- `xcodebuild test -scheme EnFlow -destination 'platform=iOS Simulator,name=iPhone 15'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879b59f2bdc832fb21996c0c4c9aca3