### PR TITLE
Add Heart Rate usage description

### DIFF
--- a/EnFlow/Info.plist
+++ b/EnFlow/Info.plist
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+    <key>HKQuantityTypeIdentifierHeartRate</key>
+    <dict>
+        <key>NSHealthShareUsageDescription</key>
+        <string>Allow EnFlow to read your heart rate so we can forecast your energy levels.</string>
+    </dict>
+</dict>
 </plist>


### PR DESCRIPTION
## Summary
- ensure the Health permission prompt lists Heart Rate by adding
  `HKQuantityTypeIdentifierHeartRate` to `Info.plist`

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879d623a5a0832f9ecf843b1ecc6381