### PR TITLE
Fix bed/wake helper duplication

### DIFF
--- a/EnFlow/Energy/Calculation/EnergyForecastModel.swift
+++ b/EnFlow/Energy/Calculation/EnergyForecastModel.swift
@@ -125,6 +125,7 @@ final class EnergyForecastModel: ObservableObject {
     }
 
     wave = smooth(wave)
+    // Apply user profile's bed/wake adjustments
     shapeBedWake(for: date, profile: profile, into: &wave)
 
     let missing = Set(MetricType.allCases).subtracting(hSample.availableMetrics)
@@ -163,11 +164,14 @@ final class EnergyForecastModel: ObservableObject {
   ) -> EnergyParts? {
 
     guard let wave = forecast(for: date, health: health, events: events, profile: profile)?.values else { return nil }
-    func avg(_ s: ArraySlice<Double>) -> Double { s.reduce(0, +) / Double(s.count) * 100.0 }
+    func avg(_ range: Range<Int>) -> Double {
+      let vals = energySlice(wave, range: range)
+      return vals.reduce(0, +) / Double(vals.count) * 100.0
+    }
     return EnergyParts(
-      morning: avg(wave[6..<12]),
-      afternoon: avg(wave[12..<18]),
-      evening: avg(wave[18..<24]))
+      morning: avg(6..<12),
+      afternoon: avg(12..<18),
+      evening: avg(18..<24))
   }
 
 
@@ -300,35 +304,3 @@ final class EnergyForecastModel: ObservableObject {
   }
 }
 
-private func shapeBedWake(for date: Date,
-                          profile: UserProfile?,
-                          calendar: Calendar = .current,
-                          into wave: inout [Double]) {
-    guard let p = profile else { return }
-    let bedHr  = calendar.component(.hour, from: p.typicalSleepTime)
-    let wakeHr = calendar.component(.hour, from: p.typicalWakeTime)
-
-    // ---- Day-specific random-ish magnitude (8–15 %) ----
-    let seed = calendar.ordinality(of: .day, in: .era, for: date) ?? 0
-    let rand = Double((seed &* 1664525 &+ 1013904223) % 1000) / 1000.0
-    let mag  = 0.08 + rand * 0.07          // 0.08 … 0.15
-
-    // ---- Downtick: last 1-3 h before bed ----
-    let downSpan = max(1, Int(1 + rand * 2))  // 1-3 h
-    for i in 0..<downSpan {
-        let h = (bedHr - 1 - i + 24) % 24
-        let factor = mag * Double(i + 1) / Double(downSpan)
-        wave[h] = max(0, wave[h] - factor)
-    }
-
-    // ---- Uptick: first 1-3 h after wake ----
-    let upSpan = max(1, Int(1 + (1 - rand) * 2))  // 1-3 h (inverse of rand)
-    for i in 0..<upSpan {
-        let h = (wakeHr + i) % 24
-        let factor = mag * 0.6 * Double(upSpan - i) / Double(upSpan)
-        wave[h] = min(1, wave[h] + factor)
-    }
-
-    // ---- Hard floor for end-of-day value ----
-    wave[23] = min(wave[23], 0.50)
-}

--- a/EnFlow/Energy/Calculation/EnergySummaryEngine.swift
+++ b/EnFlow/Energy/Calculation/EnergySummaryEngine.swift
@@ -247,6 +247,7 @@ final class EnergySummaryEngine: ObservableObject {
                 wave[hr] = max(0, min(1, wave[hr] + delta))
             }
         }
+        // Apply user profile's bed/wake adjustments
         shapeBedWake(for: start, profile: profile, into: &wave)
         return wave
     }
@@ -328,35 +329,3 @@ final class EnergySummaryEngine: ObservableObject {
     }
 }
 
-private func shapeBedWake(for date: Date,
-                          profile: UserProfile?,
-                          calendar: Calendar = .current,
-                          into wave: inout [Double]) {
-    guard let p = profile else { return }
-    let bedHr  = calendar.component(.hour, from: p.typicalSleepTime)
-    let wakeHr = calendar.component(.hour, from: p.typicalWakeTime)
-
-    // ---- Day-specific random-ish magnitude (8–15 %) ----
-    let seed = calendar.ordinality(of: .day, in: .era, for: date) ?? 0
-    let rand = Double((seed &* 1664525 &+ 1013904223) % 1000) / 1000.0
-    let mag  = 0.08 + rand * 0.07          // 0.08 … 0.15
-
-    // ---- Downtick: last 1-3 h before bed ----
-    let downSpan = max(1, Int(1 + rand * 2))  // 1-3 h
-    for i in 0..<downSpan {
-        let h = (bedHr - 1 - i + 24) % 24
-        let factor = mag * Double(i + 1) / Double(downSpan)
-        wave[h] = max(0, wave[h] - factor)
-    }
-
-    // ---- Uptick: first 1-3 h after wake ----
-    let upSpan = max(1, Int(1 + (1 - rand) * 2))  // 1-3 h (inverse of rand)
-    for i in 0..<upSpan {
-        let h = (wakeHr + i) % 24
-        let factor = mag * 0.6 * Double(upSpan - i) / Double(upSpan)
-        wave[h] = min(1, wave[h] + factor)
-    }
-
-    // ---- Hard floor for end-of-day value ----
-    wave[23] = min(wave[23], 0.50)
-}

--- a/EnFlow/Views/Components/Calendar/WeekCalendarView.swift
+++ b/EnFlow/Views/Components/Calendar/WeekCalendarView.swift
@@ -300,7 +300,7 @@ struct WeekCalendarView: View {
                         scores[d] = nil
                     } else {
                         let wave = summary.hourlyWaveform.count == 24 ? summary.hourlyWaveform : Array(repeating: 0.5, count: 24)
-                        matrix[d] = Array(wave[4...23])
+                        matrix[d] = energySlice(wave, range: 4..<24)
                         scores[d] = summary.overallEnergyScore
                     }
                     events = allEvents

--- a/EnFlow/Views/DashboardView.swift
+++ b/EnFlow/Views/DashboardView.swift
@@ -319,11 +319,14 @@ struct DashboardView: View {
 
     // 3-part slices
     func slices(from wave: [Double]) -> EnergyForecastModel.EnergyParts {
-      func avg(_ s: ArraySlice<Double>) -> Double { s.reduce(0, +) / Double(s.count) * 100 }
+      func avg(_ range: Range<Int>) -> Double {
+        let vals = energySlice(wave, range: range)
+        return vals.reduce(0, +) / Double(vals.count) * 100
+      }
       return EnergyForecastModel.EnergyParts(
-        morning: avg(wave[6..<12]),
-        afternoon: avg(wave[12..<18]),
-        evening: avg(wave[18..<24])
+        morning: avg(6..<12),
+        afternoon: avg(12..<18),
+        evening: avg(18..<24)
       )
     }
     let tParts = slices(from: tSummary.hourlyWaveform)

--- a/EnFlowTests/EnergyWaveformValidityTests.swift
+++ b/EnFlowTests/EnergyWaveformValidityTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import EnFlow
+
+final class EnergyWaveformValidityTests: XCTestCase {
+    func testSummaryAndForecastWaveform() {
+        let cal = Calendar.current
+        let day = cal.date(from: DateComponents(year: 2025, month: 1, day: 1))!
+        var profile = UserProfile.default
+        profile.typicalWakeTime = cal.date(bySettingHour: 7, minute: 0, second: 0, of: day)!
+        profile.typicalSleepTime = cal.date(bySettingHour: 23, minute: 0, second: 0, of: day)!
+
+        let h = HealthEvent(
+            date: day,
+            hrv: 80,
+            restingHR: 55,
+            heartRate: 60,
+            sleepEfficiency: 90,
+            sleepLatency: 10,
+            deepSleep: 100,
+            remSleep: 90,
+            timeInBed: 450,
+            steps: 8000,
+            calories: 2000,
+            availableMetrics: Set(MetricType.allCases),
+            hasSamples: true
+        )
+
+        let summary = EnergySummaryEngine.shared.summarize(day: day,
+                                                           healthEvents: [h],
+                                                           calendarEvents: [],
+                                                           profile: profile)
+        XCTAssertNil(summary.warning)
+        XCTAssertEqual(summary.hourlyWaveform.count, 24)
+        for v in summary.hourlyWaveform {
+            XCTAssertFalse(v.isNaN)
+            XCTAssertGreaterThanOrEqual(v, 0)
+            XCTAssertLessThanOrEqual(v, 1)
+        }
+
+        let model = EnergyForecastModel()
+        guard let forecast = model.forecast(for: day,
+                                             health: [h],
+                                             events: [],
+                                             profile: profile) else {
+            XCTFail("No forecast")
+            return
+        }
+        XCTAssertEqual(forecast.values.count, 24)
+        for v in forecast.values {
+            XCTAssertFalse(v.isNaN)
+            XCTAssertGreaterThanOrEqual(v, 0)
+            XCTAssertLessThanOrEqual(v, 1)
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure engines reference the shared `shapeBedWake` helper

## Testing
- `xcodebuild test -scheme EnFlow -destination 'platform=iOS Simulator,name=iPhone 15'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a797fa7d8832fa55230235ace8ab8