### PR TITLE
Fix energy eligibility for zero-value metrics

### DIFF
--- a/EnFlow/Energy/Data/HealthDataPipeline.swift
+++ b/EnFlow/Energy/Data/HealthDataPipeline.swift
@@ -62,40 +62,40 @@ final class HealthDataPipeline: ObservableObject {
             let next = calendar.date(byAdding: .day, value: 1, to: day)!
 
             // --- Quantities ————————————————————
-            let hrvMs = await averageQuantity(.heartRateVariabilitySDNN,
-                                              unit: HKUnit.secondUnit(with: .milli),
-                                              start: day, end: next)
+            let (hrvMs, hrvValid) = await averageQuantity(.heartRateVariabilitySDNN,
+                                                         unit: HKUnit.secondUnit(with: .milli),
+                                                         start: day, end: next)
 
-            let restHR = await averageQuantity(.restingHeartRate,
-                                               unit: HKUnit.count().unitDivided(by: HKUnit.minute()),
-                                               start: day, end: next)
+            let (restHR, restValid) = await averageQuantity(.restingHeartRate,
+                                                            unit: HKUnit.count().unitDivided(by: HKUnit.minute()),
+                                                            start: day, end: next)
 
-            let avgHR = await averageQuantity(.heartRate,
-                                             unit: HKUnit.count().unitDivided(by: HKUnit.minute()),
-                                             start: day, end: next)
+            let (avgHR, hrValid) = await averageQuantity(.heartRate,
+                                                        unit: HKUnit.count().unitDivided(by: HKUnit.minute()),
+                                                        start: day, end: next)
 
-            let steps  = await sumQuantity(.stepCount,
-                                           unit: .count(),
-                                           start: day, end: next)
+            let (steps, stepsValid)  = await sumQuantity(.stepCount,
+                                                        unit: .count(),
+                                                        start: day, end: next)
 
-            let calories = await sumQuantity(.activeEnergyBurned,
-                                             unit: .kilocalorie(),
-                                             start: day, end: next)
+            let (calories, caloriesValid) = await sumQuantity(.activeEnergyBurned,
+                                                             unit: .kilocalorie(),
+                                                             start: day, end: next)
 
             // --- Sleep metrics ————————————————
-            let (eff, lat, deep, rem, inBed) = await parseSleepMetrics(start: day, end: next)
+            let (eff, lat, deep, rem, inBed, sleepValid) = await parseSleepMetrics(start: day, end: next)
 
             var metrics: Set<MetricType> = []
-            if steps > 0        { metrics.insert(.stepCount) }
-            if restHR > 0       { metrics.insert(.restingHR) }
-            if avgHR > 0        { metrics.insert(.heartRate) }
-            if calories > 0     { metrics.insert(.activeEnergyBurned) }
-            if hrvMs > 0        { metrics.insert(.heartRateVariabilitySDNN) }
-            if eff > 0          { metrics.insert(.sleepEfficiency) }
-            if lat > 0          { metrics.insert(.sleepLatency) }
-            if deep > 0         { metrics.insert(.deepSleep) }
-            if rem > 0          { metrics.insert(.remSleep) }
-            if inBed > 0        { metrics.insert(.timeInBed) }
+            if stepsValid       { metrics.insert(.stepCount) }
+            if restValid        { metrics.insert(.restingHR) }
+            if hrValid          { metrics.insert(.heartRate) }
+            if caloriesValid    { metrics.insert(.activeEnergyBurned) }
+            if hrvValid         { metrics.insert(.heartRateVariabilitySDNN) }
+            if eff > 0 && sleepValid { metrics.insert(.sleepEfficiency) }
+            if lat > 0 && sleepValid { metrics.insert(.sleepLatency) }
+            if deep > 0 && sleepValid { metrics.insert(.deepSleep) }
+            if rem > 0 && sleepValid { metrics.insert(.remSleep) }
+            if sleepValid       { metrics.insert(.timeInBed) }
 
             let hasData = !metrics.isEmpty
             if !hasData {
@@ -127,16 +127,19 @@ final class HealthDataPipeline: ObservableObject {
     private func averageQuantity(_ id: HKQuantityTypeIdentifier,
                                  unit: HKUnit,
                                  start: Date,
-                                 end: Date) async -> Double {
-        guard let type = HKObjectType.quantityType(forIdentifier: id) else { return 0 }
+                                 end: Date) async -> (Double, Bool) {
+        guard let type = HKObjectType.quantityType(forIdentifier: id) else { return (0, false) }
         let predicate = HKQuery.predicateForSamples(withStart: start, end: end)
 
         return await withCheckedContinuation { cont in
             let q = HKStatisticsQuery(quantityType: type,
                                       quantitySamplePredicate: predicate,
                                       options: .discreteAverage) { _, stats, _ in
-                let val = stats?.averageQuantity()?.doubleValue(for: unit) ?? 0
-                cont.resume(returning: val)
+                if let qty = stats?.averageQuantity() {
+                    cont.resume(returning: (qty.doubleValue(for: unit), true))
+                } else {
+                    cont.resume(returning: (0, false))
+                }
             }
             store.execute(q)
         }
@@ -145,23 +148,26 @@ final class HealthDataPipeline: ObservableObject {
     private func sumQuantity(_ id: HKQuantityTypeIdentifier,
                              unit: HKUnit,
                              start: Date,
-                             end: Date) async -> Double {
-        guard let type = HKObjectType.quantityType(forIdentifier: id) else { return 0 }
+                             end: Date) async -> (Double, Bool) {
+        guard let type = HKObjectType.quantityType(forIdentifier: id) else { return (0, false) }
         let predicate = HKQuery.predicateForSamples(withStart: start, end: end)
 
         return await withCheckedContinuation { cont in
             let q = HKStatisticsQuery(quantityType: type,
                                       quantitySamplePredicate: predicate,
                                       options: .cumulativeSum) { _, stats, _ in
-                let val = stats?.sumQuantity()?.doubleValue(for: unit) ?? 0
-                cont.resume(returning: val)
+                if let qty = stats?.sumQuantity() {
+                    cont.resume(returning: (qty.doubleValue(for: unit), true))
+                } else {
+                    cont.resume(returning: (0, false))
+                }
             }
             store.execute(q)
         }
     }
 
-    private func parseSleepMetrics(start: Date, end: Date) async -> (eff: Double, latency: Double, deep: Double, rem: Double, inBed: Double) {
-        guard let sleepType = HKObjectType.categoryType(forIdentifier: .sleepAnalysis) else { return (0,0,0,0,0) }
+    private func parseSleepMetrics(start: Date, end: Date) async -> (eff: Double, latency: Double, deep: Double, rem: Double, inBed: Double, valid: Bool) {
+        guard let sleepType = HKObjectType.categoryType(forIdentifier: .sleepAnalysis) else { return (0,0,0,0,0,false) }
         let predicate = HKQuery.predicateForSamples(withStart: start, end: end)
 
         return await withCheckedContinuation { cont in
@@ -171,6 +177,7 @@ final class HealthDataPipeline: ObservableObject {
                                    sortDescriptors: nil) { _, samples, _ in
                 var total = 0.0, asleep = 0.0, latency = 0.0, deep = 0.0, rem = 0.0
                 var firstStart: Date?, lastEnd: Date?
+                let hasSamples = !(samples ?? []).isEmpty
 
                 for case let s as HKCategorySample in samples ?? [] {
                     let dur = s.endDate.timeIntervalSince(s.startDate)
@@ -191,7 +198,7 @@ final class HealthDataPipeline: ObservableObject {
                 }
                 let efficiency = total > 0 ? asleep / total * 100 : 0
                 let inBed = (firstStart != nil && lastEnd != nil) ? lastEnd!.timeIntervalSince(firstStart!) / 60.0 : 0
-                cont.resume(returning: (efficiency, latency/60, deep/60, rem/60, inBed))
+                cont.resume(returning: (efficiency, latency/60, deep/60, rem/60, inBed, hasSamples))
             }
             store.execute(q)
         }
@@ -207,10 +214,10 @@ final class HealthDataPipeline: ObservableObject {
 
         let start = calendar.startOfDay(for: Date())
         let end   = calendar.date(byAdding: .day, value: 1, to: start)!
-        let count = await sumQuantity(.stepCount,
-                                      unit: .count(),
-                                      start: start,
-                                      end: end)
+        let (count, _) = await sumQuantity(.stepCount,
+                                           unit: .count(),
+                                           start: start,
+                                           end: end)
         return Int(count)
     }
 


### PR DESCRIPTION
## Summary
- treat HealthKit metrics as present when samples exist even if the value is zero
- update `HealthDataPipeline` helper queries to return a flag indicating whether data was found
- include this flag when calculating `availableMetrics`

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*


------
https://chatgpt.com/codex/tasks/task_e_687a85567a9c832fbd9f9fd358cfd4be