### PR TITLE
Call shapeBedWake in waveform builders

### DIFF
--- a/EnFlow/Energy/Calculation/EnergyForecastModel.swift
+++ b/EnFlow/Energy/Calculation/EnergyForecastModel.swift
@@ -9,6 +9,7 @@
 import Combine
 import Foundation
 import HealthKit
+import EnergyUtils
 
 // MARK: - EnergyForecastModel ---------------------------------------------------
 @MainActor
@@ -126,6 +127,7 @@ final class EnergyForecastModel: ObservableObject {
 
     wave = smooth(wave)
     // Apply user profile's bed/wake adjustments
+    shapeBedWake(for: date, profile: profile, calendar: calendar, into: &wave)
 
 
     let missing = Set(MetricType.allCases).subtracting(hSample.availableMetrics)

--- a/EnFlow/Energy/Calculation/EnergySummaryEngine.swift
+++ b/EnFlow/Energy/Calculation/EnergySummaryEngine.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import HealthKit
+import EnergyUtils
 
 // MARK: – Day-level output ------------------------------------------------------
 
@@ -248,7 +249,8 @@ final class EnergySummaryEngine: ObservableObject {
             }
         }
         // Apply user profile's bed/wake adjustments
-        
+        shapeBedWake(for: start, profile: profile, calendar: calendar, into: &wave)
+
         return wave
     }
 


### PR DESCRIPTION
## Summary
- ensure the summary engine and forecast model apply bed/wake shaping
- expose EnergyUtils in both calculation files

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687a91114600832f96ff08b4ea2aea0d