### PR TITLE
Enable tomorrow forecast in day view

### DIFF
--- a/EnFlow/Views/Components/Calendar/DayView.swift
+++ b/EnFlow/Views/Components/Calendar/DayView.swift
@@ -472,6 +472,7 @@ struct DayView: View {
   // MARK: ─ Data loader ───────────────────────────────────────
   private func load() async {
     let startOfToday = calendar.startOfDay(for: Date())
+    let startOfTomorrow = calendar.date(byAdding: .day, value: 1, to: startOfToday)!
     let diff = calendar.dateComponents([.day], from: currentDate, to: startOfToday).day ?? 0
     let daysBack = max(7, diff + 1)
     let healthList = await HealthDataPipeline.shared.fetchDailyHealthEvents(daysBack: daysBack)
@@ -500,7 +501,8 @@ struct DayView: View {
       forecast = []
     }
 
-    showHeatMap = currentDate <= startOfToday &&
+    showHeatMap = (currentDate <= startOfToday ||
+                   calendar.isDate(currentDate, inSameDayAs: startOfTomorrow)) &&
                  summary.warning != "Insufficient health data"
     if showHeatMap {
       overallScore = summary.overallEnergyScore

--- a/EnFlow/Views/Components/Calendar/WeekCalendarView.swift
+++ b/EnFlow/Views/Components/Calendar/WeekCalendarView.swift
@@ -69,7 +69,6 @@ struct WeekCalendarView: View {
                                     // Score now matches DayView
                                     energyChip(score: dayScores[day])
                                         .saturation(isTomorrow ? 0.7 : 1)
-                                        .overlay(isTomorrow ? DotPatternOverlay(color: .white).opacity(0.4) : nil)
                                 }
                                 .frame(maxWidth: .infinity)
                                 .padding(6)


### PR DESCRIPTION
## Summary
- allow energy visualizations for tomorrow in `DayView`
- keep week header score chip clean of dot overlay

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project EnFlow.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a92bff224832fa07063a027042b04