### PR TITLE
Share circadian boost constant

### DIFF
--- a/EnFlow/Energy/Calculation/EnergyForecastModel.swift
+++ b/EnFlow/Energy/Calculation/EnergyForecastModel.swift
@@ -282,14 +282,6 @@ final class EnergyForecastModel: ObservableObject {
     return result
   }
 
-  /// Consensus circadian energy curve (dips ≈ 2 am & 3 pm; peaks ≈ 10 am & 6 pm)
-  private let circadianBoost: [Double] = [
-    -0.05, -0.05, -0.05, -0.04, -0.02,  // 0-4
-    0.02, 0.06, 0.10, 0.12, 0.10,  // 5-9
-    0.08, 0.05, 0.03, 0.00, -0.02,  // 10-14
-    -0.04, -0.03, 0.00, 0.08, 0.12,  // 15-19
-    0.10, 0.05, 0.00, -0.04,  // 20-23
-  ]
 
   private func circadian(for profile: UserProfile?) -> [Double] {
     guard let p = profile else { return circadianBoost }

--- a/EnFlow/Energy/Calculation/EnergySummaryEngine.swift
+++ b/EnFlow/Energy/Calculation/EnergySummaryEngine.swift
@@ -77,14 +77,6 @@ final class EnergySummaryEngine: ObservableObject {
     private init() {}
 
     private let calendar = Calendar.current
-    /// Fixed circadian energy curve used to weight hourly scores.
-    private let circadianBoost: [Double] = [
-        -0.05, -0.05, -0.05, -0.04, -0.02,
-        0.02, 0.06, 0.10, 0.12, 0.10,
-        0.08, 0.05, 0.03, 0.00, -0.02,
-        -0.04, -0.03, 0.00, 0.08, 0.12,
-        0.10, 0.05, 0.00, -0.04,
-    ]
 
     @MainActor @Published private(set) var refreshVersion = 0   // ring-pulse
 

--- a/EnFlow/Energy/Calculation/EnergyUtils.swift
+++ b/EnFlow/Energy/Calculation/EnergyUtils.swift
@@ -1,5 +1,14 @@
 import Foundation
 
+/// Consensus circadian energy curve used by forecasting and summary engines.
+public let circadianBoost: [Double] = [
+    -0.05, -0.05, -0.05, -0.04, -0.02,
+    0.02, 0.06, 0.10, 0.12, 0.10,
+    0.08, 0.05, 0.03, 0.00, -0.02,
+    -0.04, -0.03, 0.00, 0.08, 0.12,
+    0.10, 0.05, 0.00, -0.04,
+]
+
 /// Utility math functions used across energy models.
 func norm(_ v: Double, _ lo: Double, _ hi: Double) -> Double {
     guard hi > lo else { return 0.5 }


### PR DESCRIPTION
## Summary
- expose circadianBoost in `EnergyUtils` as a public constant
- reference the shared constant from `EnergySummaryEngine`
- reference the shared constant from `EnergyForecastModel`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687a94e86c0c832f947838c678a695a4