### PR TITLE
Fix health permission check for older iOS

### DIFF
--- a/EnFlow/Views/OnboardingAndSettingsView.swift
+++ b/EnFlow/Views/OnboardingAndSettingsView.swift
@@ -204,14 +204,19 @@ struct OnboardingAndSettingsView: View {
     }
 
     private func updateHealthGranted() {
-        //  same read type as in HealthDataPipeline
-        let readTypes: Set<HKObjectType> = [
-            .quantityType(forIdentifier: .heartRateVariabilitySDNN)!,
-            .quantityType(forIdentifier: .restingHeartRate)!,
-            .quantityType(forIdentifier: .heartRate)!,
-            .quantityType(forIdentifier: .activeEnergyBurned)!,
-            .quantityType(forIdentifier: .stepCount)!
+        //  same read types as in HealthDataPipeline. Some identifiers may be
+        //  nil on older iOS versions where those metrics don't exist yet.
+        let identifiers: [HKQuantityTypeIdentifier] = [
+            .heartRateVariabilitySDNN,
+            .restingHeartRate,
+            .heartRate,
+            .activeEnergyBurned,
+            .stepCount
         ]
+
+        let readTypes = Set(identifiers.compactMap {
+            HKObjectType.quantityType(forIdentifier: $0)
+        })
 
         HKHealthStore().getRequestStatusForAuthorization(toShare: [], read: readTypes) { status, _ in
         


### PR DESCRIPTION
## Summary
- avoid force-unwrapping health quantity types
- ignore identifiers that aren't available

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a983e0a98832f9948ac2ea84c3f0c