### PR TITLE
Handle nil from date addition

### DIFF
--- a/EnFlow/Views/DashboardView.swift
+++ b/EnFlow/Views/DashboardView.swift
@@ -395,7 +395,10 @@ struct DashboardView: View {
   private func freeBlocks(from events: [CalendarEvent], for day: Date) -> [DateInterval] {
     let cal = Calendar.current
     let startDay = cal.startOfDay(for: day)
-    let endDay = cal.date(byAdding: .day, value: 1, to: startDay)!
+    guard let endDay = cal.date(byAdding: .day, value: 1, to: startDay) else {
+      // If we can't compute the end of the day, there can be no free blocks.
+      return []
+    }
 
     let sorted = events.sorted(by: { $0.startTime < $1.startTime })
     var cursor = startDay


### PR DESCRIPTION
## Summary
- avoid force-unwrapping the end-of-day calculation in `DashboardView`
- return an empty array if the calculation fails

## Testing
- `xcodebuild -list -project EnFlow.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a99457dd8832fa59578dd3acefe15